### PR TITLE
Update tiddlers.json with new names for types tags

### DIFF
--- a/data/tiddlers.json
+++ b/data/tiddlers.json
@@ -7,7 +7,7 @@
         "id": "1",
         "id_type": "routetype_id",
         "modified": "20150303211124940",
-        "tags": "[[types de routes]]",
+        "tags": "routetype",
         "title": "Chemin"
     },
     {
@@ -36,7 +36,7 @@
         "id": "1",
         "id_type": "markertype_id",
         "modified": "20150303212309195",
-        "tags": "[[types de marqueurs]]",
+        "tags": "markertype",
         "title": "Cité"
     },
     {
@@ -47,7 +47,7 @@
         "id": "id_zoneCollines",
         "id_type": "zonetype_id",
         "modified": "20150424133447081",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Collines"
     },
     {
@@ -67,7 +67,7 @@
         "id": "4",
         "id_type": "zonetype_id",
         "modified": "20150303213126631",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Domaine"
     },
     {
@@ -78,7 +78,7 @@
         "id": "id_markerÉtablissement",
         "id_type": "markertype_id",
         "modified": "20150424205501377",
-        "tags": "[[types de marqueurs]]",
+        "tags": "markertype",
         "title": "Établissement"
     },
     {
@@ -89,7 +89,7 @@
         "id": "11",
         "id_type": "zonetype_id",
         "modified": "20150303213119104",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Failles / Falaises"
     },
     {
@@ -100,7 +100,7 @@
         "id": "8",
         "id_type": "zonetype_id",
         "modified": "20150303213111140",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Forêt"
     },
     {
@@ -111,7 +111,7 @@
         "id": "6",
         "id_type": "markertype_id",
         "modified": "20150303212300848",
-        "tags": "[[types de marqueurs]]",
+        "tags": "markertype",
         "title": "Fortifications (châteaux, angardes, rosace)"
     },
     {
@@ -122,7 +122,7 @@
         "id": "14",
         "id_type": "zonetype_id",
         "modified": "20150303213102891",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Île(s)"
     },
     {
@@ -133,7 +133,7 @@
         "id": "12",
         "id_type": "zonetype_id",
         "modified": "20150303213053711",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Landes"
     },
     {
@@ -144,7 +144,7 @@
         "id": "id_routeLiaisonMaritime",
         "id_type": "routetype_id",
         "modified": "20150424134144278",
-        "tags": "[[types de routes]]",
+        "tags": "routetype",
         "title": "Liaison maritime"
     },
     {
@@ -155,7 +155,7 @@
         "id": "id_markerHanté",
         "id_type": "markertype_id",
         "modified": "20150424205455463",
-        "tags": "[[types de marqueurs]]",
+        "tags": "markertype",
         "title": "Lieu hanté ou maudit"
     },
     {
@@ -175,7 +175,7 @@
         "id": "9",
         "id_type": "zonetype_id",
         "modified": "20150323140720835",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Marais"
     },
     {
@@ -195,7 +195,7 @@
         "id": "id_markerInvisible",
         "id_type": "markertype_id",
         "modified": "20150424134413347",
-        "tags": "[[types de marqueurs]]",
+        "tags": "markertype",
         "title": "Marqueur invisible"
     },
     {
@@ -206,7 +206,7 @@
         "id": "13",
         "id_type": "zonetype_id",
         "modified": "20150323140849179",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Mer, lac"
     },
     {
@@ -226,7 +226,7 @@
         "id": "10",
         "id_type": "zonetype_id",
         "modified": "20150323140759284",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Montagnes"
     },
     {
@@ -264,7 +264,7 @@
         "id": "3",
         "id_type": "markertype_id",
         "modified": "20150424131331102",
-        "tags": "[[types de marqueurs]]",
+        "tags": "markertype",
         "title": "Passage"
     },
     {
@@ -275,7 +275,7 @@
         "id": "id_zonePlage(s)",
         "id_type": "zonetype_id",
         "modified": "20150424134021328",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Plage(s)"
     },
     {
@@ -286,7 +286,7 @@
         "id": "id_zonePlaine(s)",
         "id_type": "zonetype_id",
         "modified": "20150424134007032",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Plaine(s)"
     },
     {
@@ -297,7 +297,7 @@
         "id": "id_zonePlateau",
         "id_type": "zonetype_id",
         "modified": "20150424133853530",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Plateau"
     },
     {
@@ -308,7 +308,7 @@
         "id": "1",
         "id_type": "zonetype_id",
         "modified": "20150303213021538",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Politique"
     },
     {
@@ -319,7 +319,7 @@
         "id": "2",
         "id_type": "markertype_id",
         "modified": "20150303212252997",
-        "tags": "[[types de marqueurs]]",
+        "tags": "markertype",
         "title": "Port (village côtier, ...)"
     },
     {
@@ -339,7 +339,7 @@
         "id": "2",
         "id_type": "routetype_id",
         "modified": "20150303211115554",
-        "tags": "[[types de routes]]",
+        "tags": "routetype",
         "title": "Route"
     },
     {
@@ -350,7 +350,7 @@
         "id": "2",
         "id_type": "zonetype_id",
         "modified": "20150303213013287",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Royaume"
     },
     {
@@ -361,7 +361,7 @@
         "id": "4",
         "id_type": "markertype_id",
         "modified": "20150303212245359",
-        "tags": "[[types de marqueurs]]",
+        "tags": "markertype",
         "title": "Sanctuaire"
     },
     {
@@ -372,7 +372,7 @@
         "id": "3",
         "id_type": "routetype_id",
         "modified": "20150303211106996",
-        "tags": "[[types de routes]]",
+        "tags": "routetype",
         "title": "Sentier de loup"
     },
     {
@@ -383,7 +383,7 @@
         "id": "5",
         "id_type": "markertype_id",
         "modified": "20150303212237549",
-        "tags": "[[types de marqueurs]]",
+        "tags": "markertype",
         "title": "Site d'intérêt"
     },
     {
@@ -394,7 +394,7 @@
         "id": "7",
         "id_type": "markertype_id",
         "modified": "20150303212227467",
-        "tags": "[[types de marqueurs]]",
+        "tags": "markertype",
         "title": "Souterrain (mine, cité troglodyte, réseau de cavernes)"
     },
     {
@@ -423,7 +423,7 @@
         "id": "7",
         "id_type": "zonetype_id",
         "modified": "20150323140959459",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Terrain"
     },
     {
@@ -434,7 +434,7 @@
         "id": "6",
         "id_type": "zonetype_id",
         "modified": "20150323140608182",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Terre sacrée"
     },
     {
@@ -445,7 +445,7 @@
         "id": "3",
         "id_type": "zonetype_id",
         "modified": "20150303212933847",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Territoire"
     },
     {
@@ -465,7 +465,7 @@
         "id": "id_markerVillage",
         "id_type": "markertype_id",
         "modified": "20150424205449249",
-        "tags": "[[types de marqueurs]]",
+        "tags": "markertype",
         "title": "Village"
     },
     {
@@ -476,7 +476,7 @@
         "id": "5",
         "id_type": "zonetype_id",
         "modified": "20150303212925343",
-        "tags": "[[types de zones]]",
+        "tags": "zonetype",
         "title": "Ville / Village"
     },
     {
@@ -487,7 +487,7 @@
         "id": "id_routeVoieFluviale",
         "id_type": "routetype_id",
         "modified": "20150424134130918",
-        "tags": "[[types de routes]]",
+        "tags": "routetype",
         "title": "Voie fluviale"
     },
     {


### PR DESCRIPTION
New names for types tags are "zonetype", "routetype" and "markertype".
The tag "factions" remains unchanged, as well as "marqueurs".

Old files (types.json, zones.json, markers.json and routes.json) are not up to date (I may delete them later).
