### PR TITLE
Add "guarded" field to all routes

### DIFF
--- a/data/tiddlers.json
+++ b/data/tiddlers.json
@@ -1001,12 +1001,40 @@
         "faction_id": "3",
         "id": "46",
         "map_id": "1",
-        "modified": "20150910202416480",
+        "modified": "20151005195428955",
         "status": "done",
         "tags": "zones",
         "title": "Archipel des Tri-Sweszörs",
-        "zoneparent_id": "57",
+        "zoneparent_id": "50",
         "zonetype_id": "14"
+    },
+    {
+        "created": "20150326114406407",
+        "text": "Cette formation rocheuse a la particularité d'être presque parfaitement circulaire. Ceux qui s'y sont rendus n'y ont rien vu sortant de l'ordinaire, contrairement à ce que clamait son découvreur Pelfreinth Argoneskan.",
+        "categorie": "cartographie",
+        "faction_id": "4",
+        "id": "47",
+        "map_id": "1",
+        "modified": "20151115192611294",
+        "status": "done",
+        "tags": "zones",
+        "title": "Cirque d'Argoneskan",
+        "zoneparent_id": "39",
+        "zonetype_id": "10"
+    },
+    {
+        "created": "20150330111310658",
+        "text": "Ces gouffres, faisant aussi office de passage à travers la chaîne des Mòr Roimh dans les Terre de Dèas, sont surnommé \"Sianail\" par les Osags. Les hurlements du vent qui s'y engouffre ou de la redoutable faune locale n'ont définitivement rien de rassurant.",
+        "categorie": "cartographie",
+        "faction_id": "4",
+        "id": "48",
+        "map_id": "1",
+        "modified": "20151115192559758",
+        "status": "done",
+        "tags": "zones",
+        "title": "Failles Hurlantes",
+        "zoneparent_id": "39",
+        "zonetype_id": "11"
     },
     {
         "text": "Cette forêt, principale ressource en bois et en gibier du Reizh, est convoité par les magientistes qui souhaitent y installer des usines d'extraction. Une légende raconte qu'un puissant féond-arbre nommé Mórcrann y aurait été vaincu.",
@@ -1037,6 +1065,34 @@
         "zonetype_id": "8"
     },
     {
+        "created": "20150414192317730",
+        "text": "Ce large golfe forme l'extrémité nord de la Mer des Linceuls, bordé par la côte du Reizh.",
+        "categorie": "cartographie",
+        "faction_id": "4",
+        "id": "50",
+        "map_id": "1",
+        "modified": "20151115192525279",
+        "status": "done",
+        "tags": "zones",
+        "title": "Golfe de Reizh",
+        "zoneparent_id": "36",
+        "zonetype_id": "13"
+    },
+    {
+        "created": "20150331111232408",
+        "text": "Ces marais moroses représentent une des rares sources de sel de toute la péninsule, et font toute la richesse du duché de Salann Tir. Les nombreux renégats qui s'y cachent, dans des ruines ou les villages les plus pauvres, se sont organisés en une bande, surnommée les \"Roseaux de fer\".",
+        "categorie": "cartographie",
+        "faction_id": "12",
+        "id": "51",
+        "map_id": "1",
+        "modified": "20151115192446383",
+        "status": "done",
+        "tags": "zones",
+        "title": "Marais du Ponant",
+        "zoneparent_id": "25",
+        "zonetype_id": "9"
+    },
+    {
         "text": "Cette région de l'ouest de Gwidre mérite véritablement son nom, tant elle est le grenier du royaume. Malgré le climat rude dû à l'exposition aux vents froids, les canaux d'irrigation aménagés autour du fleuve Pezhdour ont rendu ces plaines fertiles, et les denrées produites dans ses nombreux petits villages sont acheminées jusqu'aux provinces montagneuses.",
         "categorie": "cartographie",
         "created": "20150402181830903",
@@ -1049,34 +1105,6 @@
         "title": "Région d'Abondance",
         "zoneparent_id": "56",
         "zonetype_id": "17"
-    },
-    {
-        "text": "Cette formation rocheuse a la particularité d'être presque parfaitement circulaire. Ceux qui s'y sont rendus n'y ont rien vu sortant de l'ordinaire, contrairement à ce que clamait son découvreur Pelfreinth Argoneskan.",
-        "categorie": "cartographie",
-        "created": "20150326114406407",
-        "faction_id": "4",
-        "id": "54",
-        "map_id": "1",
-        "modified": "20150924113023827",
-        "status": "done",
-        "tags": "zones",
-        "title": "Cirque d'Argoneskan",
-        "zoneparent_id": "39",
-        "zonetype_id": "10"
-    },
-    {
-        "text": "Ces gouffres, faisant aussi office de passage à travers la chaîne des Mòr Roimh dans les Terre de Dèas, sont surnommé \"Sianail\" par les Osags. Les hurlements du vent qui s'y engouffre ou de la redoutable faune locale n'ont définitivement rien de rassurant.",
-        "categorie": "cartographie",
-        "created": "20150330111310658",
-        "faction_id": "4",
-        "id": "55",
-        "map_id": "1",
-        "modified": "20150925103817840",
-        "status": "done",
-        "tags": "zones",
-        "title": "Failles Hurlantes",
-        "zoneparent_id": "39",
-        "zonetype_id": "11"
     },
     {
         "text": "Le royaume de Gwidre se situe au nord ouest de la péninsule de Tri-Kazel, séparé de Taol-Kaer par le fleuve Kreizhdour. Le roi actuel, Dalenverch IV, gouverne depuis la capitale Ard-Amrach un peuple d'environ six cent mille habitants. Il est aidé dans sa tâche par le Hiérophante Anthénor, chef suprême du Temple. Cette religion continentale du Dieu Unique est en effet devenue la foi officielle du royaume, et les demorthèn et les anciennes traditions y sont pourchassés.",
@@ -1093,20 +1121,6 @@
         "zonetype_id": "2"
     },
     {
-        "text": "Ce large golfe forme l'extrémité nord de la Mer des Linceuls, bordé par la côte du Reizh.",
-        "categorie": "cartographie",
-        "created": "20150414192317730",
-        "faction_id": "4",
-        "id": "57",
-        "map_id": "1",
-        "modified": "20150921105615751",
-        "status": "done",
-        "tags": "zones",
-        "title": "Golfe de Reizh",
-        "zoneparent_id": "36",
-        "zonetype_id": "13"
-    },
-    {
         "text": "Le royaume de Reizh se situe à l'est de la péninsule de Tri-Kazel, séparé de Taol-Kaer par le fleuve Tealderoth et du Continent par les immenses Monts Asgeamar. Bronchaerd, le roi actuel, gouverne depuis la capitale Baldh-Ruoch un peuple d'environ cinq cent mille habitants. Le royaume a accueilli favorablement les théories magientistes et la modernité qu'elle apportent, mais sa situation politique est délicate : si la principauté de Farl, au nord, est loyale au trône, ce n'est pas le cas des seigneurs féodaux du Croissant d’Émeraude, soutenus par les demorthèn.",
         "categorie": "cartographie",
         "created": "20150323160942160",
@@ -1119,20 +1133,6 @@
         "title": "Royaume de Reizh",
         "zoneparent_id": "id_Péninsule de Tri-Kazel",
         "zonetype_id": "2"
-    },
-    {
-        "text": "Ces marais moroses représentent une des rares sources de sel de toute la péninsule, et font toute la richesse du duché de Salann Tir. Les nombreux renégats qui s'y cachent, dans des ruines ou les villages les plus pauvres, se sont organisés en une bande, surnommée les \"Roseaux de fer\".",
-        "categorie": "cartographie",
-        "created": "20150331111232408",
-        "faction_id": "12",
-        "id": "58",
-        "map_id": "1",
-        "modified": "20150922103736766",
-        "status": "done",
-        "tags": "zones",
-        "title": "Marais du Ponant",
-        "zoneparent_id": "25",
-        "zonetype_id": "9"
     },
     {
         "text": "Le Boischandelles doit son nom aux nombreux feux-follets qu'on peut y apercevoir à la nuit tombée, ce qui rend cette forêt sacrée pour les demorthèn. Ce phénomène s'est toutefois raréfié ces dernières années, alors que les feondas sont de plus en plus présents dans les environs.",
@@ -1551,18 +1551,18 @@
         "zoneparent_id": "41"
     },
     {
+        "created": "20150327121455707",
         "text": "Un étrange château abandonné. Il est si ancien que personne ne se rappelle qui l'a érigé.",
         "categorie": "cartographie",
-        "created": "20150327121455707",
         "faction_id": "4",
         "id": "122",
         "map_id": "1",
         "markertype_id": "5",
-        "modified": "20150721191152782",
+        "modified": "20151115192505724",
         "status": "à revoir",
         "tags": "marqueurs",
         "title": "Castel des Roseaux",
-        "zoneparent_id": "58"
+        "zoneparent_id": "51"
     },
     {
         "text": "Cette forteresse située sur les terres de Dèas est entretenue et rénovée par les osags.",
@@ -2375,11 +2375,11 @@
         "id": "24",
         "map_id": "1",
         "markertype_id": "5",
-        "modified": "20150711170934861",
+        "modified": "20151005195614997",
         "status": "done",
         "tags": "marqueurs",
         "title": "Entrée du cirque d'Argoneskan",
-        "zoneparent_id": "54"
+        "zoneparent_id": "47"
     },
     {
         "text": "Cette petite cité sainte à l'extrême nord de Gwidre est un des principaux ports sur cette côte. Elle accueille le puissant ordre monastique du reliquaire, dont le recteur est le chef de l'ordre des moines. Les pèlerins affluent lorsque des reliques de saints, ordinairement conservées dans le monastère, sont exposées.",
@@ -3494,6 +3494,7 @@
         "categorie": "cartographie",
         "created": "20150318132437138",
         "faction_id": "2",
+        "guarded": "false",
         "id": "10",
         "itineraire": "Route des Cendres",
         "map_id": "1",
@@ -3504,14 +3505,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route des Cendres",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331121003351",
         "faction_id": "4",
+        "guarded": "false",
         "id": "100",
         "itineraire": "Route de l'Océan",
         "map_id": "1",
@@ -3522,14 +3523,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Océan (de Gorm Caladh à Saint Albérich)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331120829362",
         "faction_id": "4",
+        "guarded": "false",
         "id": "101",
         "itineraire": "Route de l'Océan",
         "map_id": "1",
@@ -3540,14 +3541,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Océan (de Saint Albérich à Aimliù)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331121541927",
         "faction_id": "10",
+        "guarded": "false",
         "id": "102",
         "itineraire": "Route de l'Océan",
         "map_id": "1",
@@ -3558,14 +3559,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Océan (de Tulg Naomh au bac)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331121412194",
         "faction_id": "10",
+        "guarded": "false",
         "id": "103",
         "itineraire": "Route de l'Océan",
         "map_id": "1",
@@ -3576,14 +3577,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Océan (du bac à Gorm Caladh)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331123756853",
         "faction_id": "14",
+        "guarded": "false",
         "id": "104",
         "itineraire": "Route des Hilderins",
         "map_id": "1",
@@ -3594,14 +3595,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route des Hilderins (d'Ostreach à Tilliarch)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150318164711547",
         "faction_id": "14",
+        "guarded": "false",
         "id": "105",
         "itineraire": "Route des Hilderins",
         "map_id": "1",
@@ -3612,14 +3613,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route des Hilderins (de Merieren à Ostreach)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331123715979",
         "faction_id": "14",
+        "guarded": "false",
         "id": "106",
         "itineraire": "Route des Hilderins",
         "map_id": "1",
@@ -3630,14 +3631,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route des Hilderins (de Tilliarch à la Citadelle de Dèas)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150723200434044",
         "faction_id": "11",
+        "guarded": "false",
         "id": "107",
         "itineraire": "",
         "map_id": "1",
@@ -3648,14 +3649,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du port de Farl",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331123445546",
         "faction_id": "",
+        "guarded": "false",
         "id": "108",
         "map_id": "1",
         "markerend_id": "84",
@@ -3665,14 +3666,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin d'Ostreach à Cardach",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331114958392",
         "faction_id": "1",
+        "guarded": "false",
         "id": "109",
         "map_id": "1",
         "markerend_id": "170",
@@ -3682,14 +3683,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin gwidrite de Corvus à Kermordhran",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150330133957606",
         "faction_id": "11",
+        "guarded": "false",
         "id": "11",
         "itineraire": "Route royale (itinéraire)",
         "map_id": "1",
@@ -3700,14 +3701,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route royale (de Kalvernach à la demeure des Mac Baellec)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150721220949888",
         "faction_id": "1",
+        "guarded": "false",
         "id": "110",
         "itineraire": "Chemin de Norgord",
         "map_id": "1",
@@ -3718,14 +3719,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Norgord (de Kroazen aux carrières de Norgord)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Le route qui mène aux carrières de marbre blanc du plateau de Norgord a été financée par le clergé du Temple, qui l'apprécie pour la construction de ses églises.",
         "categorie": "cartographie",
         "created": "20150331115347013",
         "faction_id": "1",
+        "guarded": "false",
         "id": "111",
         "itineraire": "Chemin de Norgord",
         "map_id": "1",
@@ -3736,14 +3737,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Norgord (du carrefour du pic Ordachaï à Kroazen)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331124358528",
         "faction_id": "15",
+        "guarded": "false",
         "id": "112",
         "map_id": "1",
         "markerend_id": "96",
@@ -3753,14 +3754,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Terkhên à Melwan",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331122230161",
         "faction_id": "",
+        "guarded": "false",
         "id": "113",
         "map_id": "1",
         "markerend_id": "47",
@@ -3770,14 +3771,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Terkhên à Tulg Naomh",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331123855855",
         "faction_id": "15",
+        "guarded": "false",
         "id": "114",
         "map_id": "1",
         "markerend_id": "127",
@@ -3787,14 +3788,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Terkhên au Col de Lochre",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331123109083",
         "faction_id": "15",
+        "guarded": "false",
         "id": "115",
         "map_id": "1",
         "markerend_id": "160",
@@ -3804,14 +3805,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Tùrsal (des Salicornes au carrefour d'Eaux-Salées)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331123609811",
         "faction_id": "15",
+        "guarded": "false",
         "id": "116",
         "map_id": "1",
         "markerend_id": "160",
@@ -3821,14 +3822,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers la Citadelle de Dèas",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331122929744",
         "faction_id": "15",
+        "guarded": "false",
         "id": "117",
         "map_id": "1",
         "markerend_id": "133",
@@ -3838,14 +3839,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Tùrsal (du carrefour d'Eaux-Salées à Louarn)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331130711257",
         "faction_id": "",
+        "guarded": "false",
         "id": "118",
         "map_id": "1",
         "markerend_id": "63",
@@ -3855,14 +3856,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Brégan à Koskan",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331130632674",
         "faction_id": "",
+        "guarded": "false",
         "id": "119",
         "map_id": "1",
         "markerend_id": "8",
@@ -3872,14 +3873,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Brégan à Osta-Baille",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150330134231644",
         "faction_id": "4",
+        "guarded": "false",
         "id": "12",
         "itineraire": "",
         "map_id": "1",
@@ -3890,14 +3891,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin d'Afalinn",
-        "zoneparent_id": "57",
-        "guarded": "false"
+        "zoneparent_id": "57"
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331115926300",
         "faction_id": "",
+        "guarded": "false",
         "id": "120",
         "map_id": "1",
         "markerend_id": "35",
@@ -3907,14 +3908,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Crail à Gline",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331131112901",
         "faction_id": "",
+        "guarded": "false",
         "id": "121",
         "map_id": "1",
         "markerend_id": "73",
@@ -3924,14 +3925,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Kaer Daegis à Kel Loar",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331131012877",
         "faction_id": "",
+        "guarded": "false",
         "id": "122",
         "map_id": "1",
         "markerend_id": "72",
@@ -3941,14 +3942,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Kaer Daegis à Seòl",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331131230901",
         "faction_id": "",
+        "guarded": "false",
         "id": "123",
         "map_id": "1",
         "markerend_id": "11",
@@ -3958,14 +3959,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Kel Loar au Pont de l'Alliance",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Le développement de cette route reliant Farl à Kell est un enjeu économique pour cette dernière.",
         "categorie": "cartographie",
         "created": "20150318162550775",
         "faction_id": "",
+        "guarded": "false",
         "id": "124",
         "map_id": "1",
         "markerend_id": "21",
@@ -3975,14 +3976,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Kell à Farl",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331130522964",
         "faction_id": "",
+        "guarded": "false",
         "id": "125",
         "map_id": "1",
         "markerend_id": "35",
@@ -3992,14 +3993,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du Carrefour de Ruel à Gline",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331130317573",
         "faction_id": "",
+        "guarded": "false",
         "id": "126",
         "map_id": "1",
         "markerend_id": "60",
@@ -4009,14 +4010,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du Carrefour de Ruel à Mùdan",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Cette route relie Kermordhran au Clos-des-Cendres. Des angardes bien entretenues la jalonnent, et des patrouilles la parcourent régulièrement.",
         "categorie": "cartographie",
         "created": "20150318133608398",
         "faction_id": "2",
+        "guarded": "false",
         "id": "13",
         "itineraire": "Route de la mer",
         "map_id": "1",
@@ -4027,14 +4028,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de la mer (de Kermordhran au carrefour du cirque d'Argoneskan)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Cette route qui relie Fionnfuar et Farl, dont les habitants l'appellent aussi \"Route de l'ouest\" ou \"Route marine\", est moins développée du côté gwidrite.",
         "categorie": "cartographie",
         "created": "20150330134443768",
         "faction_id": "1",
+        "guarded": "false",
         "id": "14",
         "itineraire": "Route des Cendres",
         "map_id": "1",
@@ -4045,14 +4046,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Farl",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Aussi appelé \"passage des Brumes\", ce sentier est la plus ancienne voie connue pour traverser les montagnes, aussi spectaculaire que dangereuse.",
         "categorie": "cartographie",
         "created": "20150327114440646",
         "faction_id": "15",
+        "guarded": "false",
         "id": "146",
         "map_id": "1",
         "markerend_id": "159",
@@ -4062,14 +4063,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier d'Aisir Ceòmhor",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150823095607415",
         "faction_id": "15",
+        "guarded": "false",
         "id": "147",
         "itineraire": "",
         "map_id": "1",
@@ -4081,14 +4082,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin d'Aisir Ceòmhor au col de l'Artz",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331123339344",
         "faction_id": "15",
+        "guarded": "false",
         "id": "148",
         "map_id": "1",
         "markerend_id": "130",
@@ -4098,14 +4099,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Cardach à la Brèche du loup",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331124717534",
         "faction_id": "15",
+        "guarded": "false",
         "id": "149",
         "map_id": "1",
         "markerend_id": "49",
@@ -4115,14 +4116,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Dearg à Fearìl",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331124838122",
         "faction_id": "15",
+        "guarded": "false",
         "id": "150",
         "map_id": "1",
         "markerend_id": "51",
@@ -4132,14 +4133,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Dearg à Loch Varn",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150823095712535",
         "faction_id": "15",
+        "guarded": "false",
         "id": "151",
         "itineraire": "",
         "map_id": "1",
@@ -4151,14 +4152,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier de Didean à Aisir Ceòmhor",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150409120858799",
         "faction_id": "14",
+        "guarded": "false",
         "id": "152",
         "map_id": "1",
         "markerend_id": "50",
@@ -4168,13 +4169,13 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Fearìl à la forteresse de Smiorail",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "faction_id": "15",
+        "guarded": "false",
         "id": "153",
         "itineraire": "",
         "map_id": "1",
@@ -4186,14 +4187,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de l'abbaye de Corvus à la route du Dorchwald",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331123158011",
         "faction_id": "15",
+        "guarded": "false",
         "id": "154",
         "map_id": "1",
         "markerend_id": "92",
@@ -4203,14 +4204,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de la Brèche du loup à Deanaidh",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150823075449634",
         "faction_id": "14",
+        "guarded": "false",
         "id": "155",
         "itineraire": "",
         "map_id": "1",
@@ -4222,14 +4223,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de la forteresse de Smiorail au Col de Lantrech",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331120029388",
         "faction_id": "15",
+        "guarded": "false",
         "id": "156",
         "map_id": "1",
         "markerend_id": "71",
@@ -4239,14 +4240,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour gwidrite d'Aelwyd Saogh à Expiation",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331125215597",
         "faction_id": "15",
+        "guarded": "false",
         "id": "157",
         "map_id": "1",
         "markerend_id": "52",
@@ -4256,14 +4257,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Loch Varn au Col d'Oerdh",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331124536269",
         "faction_id": "15",
+        "guarded": "false",
         "id": "158",
         "map_id": "1",
         "markerend_id": "48",
@@ -4273,14 +4274,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Melwan à Dearg",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331125030650",
         "faction_id": "15",
+        "guarded": "false",
         "id": "159",
         "map_id": "1",
         "markerend_id": "51",
@@ -4290,14 +4291,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Melwan à Loch Varn",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Ce chemin permet de joindre Nectan à Deh'ad. Moins utilisé que la célèbre Voie sainte, il suit la lisière entre la forêt du Dorchwald et les contreforts des Mòr Roimh.",
         "categorie": "cartographie",
         "created": "20150330134621191",
         "faction_id": "15",
+        "guarded": "false",
         "id": "16",
         "itineraire": "Route du Dorchwald",
         "map_id": "1",
@@ -4308,14 +4309,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Route du Dorchwald (de Nectan à Lenbach)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906134754457",
         "faction_id": "15",
+        "guarded": "false",
         "id": "160",
         "itineraire": "",
         "map_id": "1",
@@ -4327,14 +4328,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Terkhên à Frendian",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150823084641737",
         "faction_id": "15",
+        "guarded": "false",
         "id": "161",
         "itineraire": "",
         "map_id": "1",
@@ -4346,13 +4347,13 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du col d'Oerdh à la route des Hilderins",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "faction_id": "15",
+        "guarded": "false",
         "id": "162",
         "itineraire": "",
         "map_id": "1",
@@ -4364,14 +4365,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du col de l'Artz à Tilliarch",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331124108413",
         "faction_id": "15",
+        "guarded": "false",
         "id": "163",
         "map_id": "1",
         "markerend_id": "id_Aisir Ceòmhor (est)",
@@ -4381,14 +4382,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du col de Lochre à Aisir Ceòmhor",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150823071015542",
         "faction_id": "15",
+        "guarded": "false",
         "id": "164",
         "itineraire": "",
         "map_id": "1",
@@ -4400,14 +4401,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers Jarnel",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150823090035289",
         "faction_id": "9",
+        "guarded": "false",
         "id": "165",
         "itineraire": "",
         "map_id": "1",
@@ -4419,14 +4420,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers les carrières d'Arden",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150409123253122",
         "faction_id": "4",
+        "guarded": "false",
         "id": "166",
         "map_id": "1",
         "markerend_id": "105",
@@ -4436,14 +4437,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "De Seòl à Smàrag en char à voile",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150409124212662",
         "faction_id": "4",
+        "guarded": "false",
         "id": "167",
         "map_id": "1",
         "markerend_id": "63",
@@ -4453,14 +4454,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "De Smàrag à Koskan en char à voile",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331122429397",
         "faction_id": "15",
+        "guarded": "false",
         "id": "168",
         "map_id": "1",
         "markerend_id": "122",
@@ -4470,14 +4471,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Piste des Roseaux",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150823090629471",
         "faction_id": "13",
+        "guarded": "false",
         "id": "169",
         "itineraire": "",
         "map_id": "1",
@@ -4489,14 +4490,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Ouest (de Crail à Leacach)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Ce chemin poussiéreux mène, à travers un paysage accidenté, au manoir des Hauts-Vents.",
         "categorie": "cartographie",
         "created": "20150322085613795",
         "faction_id": "15",
+        "guarded": "false",
         "id": "17",
         "itineraire": "",
         "map_id": "1",
@@ -4507,14 +4508,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Chemin des Hauts-Vents",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Ce chemin permet de joindre Nectan à Deh'ad. Moins utilisé que la célèbre Voie sainte, il suit la lisière entre la forêt du Dorchwald et les contreforts des Mòr Roimh.",
         "categorie": "cartographie",
         "created": "20150823081110171",
         "faction_id": "15",
+        "guarded": "false",
         "id": "170",
         "itineraire": "Route du Dorchwald",
         "map_id": "1",
@@ -4526,14 +4527,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Route du Dorchwald (du carrefour de Corvus au carrefour des Pierres Brisées)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Cette route, qui mène de Baldh-Ruoch à Kell en traversant la forêt de Taelwald, est un sujet de tension entre les magientistes, qui souhaiteraient la développer pour favoriser l'essor économique de Kell, et les demorthèn, qui veulent protéger la forêt.",
         "categorie": "cartographie",
         "created": "20150318135204506",
         "faction_id": "11",
+        "guarded": "false",
         "id": "171",
         "map_id": "1",
         "markerend_id": "147",
@@ -4543,13 +4544,13 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du Taelwald (de Baldh-Ruoch au carrefour de l'Arbre de l'Automne)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Cette route, qui mène de Baldh-Ruoch à Kell en traversant la forêt de Taelwald, est un sujet de tension entre les magientistes, qui souhaiteraient la développer pour favoriser l'essor économique de Kell, et les demorthèn, qui veulent protéger la forêt.",
         "categorie": "cartographie",
         "faction_id": "11",
+        "guarded": "false",
         "id": "172",
         "itineraire": "",
         "map_id": "1",
@@ -4561,13 +4562,13 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du Taelwald (du carrefour de l'Arbre de l'Automne à Kell)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "faction_id": "3",
+        "guarded": "false",
         "id": "173",
         "itineraire": "",
         "map_id": "1",
@@ -4579,14 +4580,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier vers l'Arbre de l'Automne",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Comme le cours du Donir n'est pas navigable, une route longe le fleuve afin de rejoindre la capitale Baldh-Ruoch depuis le port d'Ear Caladh.",
         "categorie": "cartographie",
         "created": "20150403140839944",
         "faction_id": "13",
+        "guarded": "false",
         "id": "174",
         "map_id": "1",
         "markerend_id": "42",
@@ -4596,14 +4597,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Donir (de Baldh-Ruoch à Ear Caladh)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150823091831408",
         "faction_id": "15",
+        "guarded": "false",
         "id": "175",
         "itineraire": "",
         "map_id": "1",
@@ -4615,14 +4616,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Kreizhdour (d'Arngyll au bac)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150823091824034",
         "faction_id": "15",
+        "guarded": "false",
         "id": "176",
         "itineraire": "",
         "map_id": "1",
@@ -4634,14 +4635,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Kreizhdour (de Fearìl au col de Siagal)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331125431666",
         "faction_id": "15",
+        "guarded": "false",
         "id": "177",
         "map_id": "1",
         "markerend_id": "164",
@@ -4651,14 +4652,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Caiginn au carrefour de Thòl",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829141837745",
         "faction_id": "15",
+        "guarded": "false",
         "id": "178",
         "itineraire": "",
         "map_id": "1",
@@ -4670,14 +4671,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Tùrsal (de Deanaidh aux Salicornes)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829143910887",
         "faction_id": "15",
+        "guarded": "false",
         "id": "179",
         "itineraire": "",
         "map_id": "1",
@@ -4689,14 +4690,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du bac du Kreizhdour à Mambrun",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Les ouvriers qui empruntent ce chemin pour travailler aux mines de Promesse sont escortés par des hommes d'armes, en raison des raids fréquents menés par les clans osags.",
         "categorie": "cartographie",
         "created": "20150330135135488",
         "faction_id": "2",
+        "guarded": "false",
         "id": "18",
         "map_id": "1",
         "markerend_id": "38",
@@ -4706,14 +4707,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Chemin des mines de Promesse",
-        "zoneparent_id": "57",
-        "guarded": "false"
+        "zoneparent_id": "57"
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829145558904",
         "faction_id": "15",
+        "guarded": "false",
         "id": "180",
         "itineraire": "",
         "map_id": "1",
@@ -4725,14 +4726,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Thòl au carrefour de Thòl",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Cette ancienne route traverse la forêt des Soupirs et permet de rejoindre Terkhên.",
         "categorie": "cartographie",
         "created": "20150829144642730",
         "faction_id": "15",
+        "guarded": "false",
         "id": "181",
         "itineraire": "",
         "map_id": "1",
@@ -4744,14 +4745,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour de Laräch à Terkhên",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829150038666",
         "faction_id": "1",
+        "guarded": "false",
         "id": "182",
         "itineraire": "",
         "map_id": "1",
@@ -4763,14 +4764,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour de Thòl à Expiation",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829145408462",
         "faction_id": "15",
+        "guarded": "false",
         "id": "183",
         "itineraire": "",
         "map_id": "1",
@@ -4782,14 +4783,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du col de Lantrech à Thòl",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829150423510",
         "faction_id": "15",
+        "guarded": "false",
         "id": "184",
         "itineraire": "",
         "map_id": "1",
@@ -4801,14 +4802,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers Gleb",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829154300174",
         "faction_id": "15",
+        "guarded": "false",
         "id": "185",
         "itineraire": "",
         "map_id": "1",
@@ -4820,14 +4821,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers Helefrt",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829150236706",
         "faction_id": "9",
+        "guarded": "false",
         "id": "186",
         "itineraire": "",
         "map_id": "1",
@@ -4839,14 +4840,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers la citadelle de Kermordhran",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829142803299",
         "faction_id": "9",
+        "guarded": "false",
         "id": "187",
         "itineraire": "",
         "map_id": "1",
@@ -4858,14 +4859,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers le château des Mac Readan",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829142914432",
         "faction_id": "9",
+        "guarded": "false",
         "id": "188",
         "itineraire": "",
         "map_id": "1",
@@ -4877,14 +4878,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers le château des Mac Tremen",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829150340903",
         "faction_id": "15",
+        "guarded": "false",
         "id": "189",
         "itineraire": "",
         "map_id": "1",
@@ -4896,14 +4897,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers le château des Roharën",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829145508144",
         "faction_id": "1",
+        "guarded": "false",
         "id": "190",
         "itineraire": "",
         "map_id": "1",
@@ -4915,14 +4916,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers le monastère de Tuath",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829141120623",
         "faction_id": "3",
+        "guarded": "false",
         "id": "191",
         "itineraire": "",
         "map_id": "1",
@@ -4934,14 +4935,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers les alignements de Tùrsal",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829182612831",
         "faction_id": "11",
+        "guarded": "false",
         "id": "192",
         "itineraire": "",
         "map_id": "1",
@@ -4953,14 +4954,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de la côte d'Émeraude (de Nua Caladh au pont de Brian'ch)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829154201559",
         "faction_id": "15",
+        "guarded": "false",
         "id": "193",
         "itineraire": "",
         "map_id": "1",
@@ -4972,14 +4973,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du Grand Est (du carrefour de Gleb à Iolairnead)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829182209295",
         "faction_id": "11",
+        "guarded": "false",
         "id": "194",
         "itineraire": "Route royale (itinéraire)",
         "map_id": "1",
@@ -4991,14 +4992,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route royale (d'Afalinn au pont sur le Donir de Kember)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829181912637",
         "faction_id": "11",
+        "guarded": "false",
         "id": "195",
         "itineraire": "Route royale (itinéraire)",
         "map_id": "1",
@@ -5010,14 +5011,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route royale (du carrefour de Promesse à Afalinn)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150805122153565",
         "faction_id": "9",
+        "guarded": "false",
         "id": "196",
         "itineraire": "Route royale (itinéraire)",
         "map_id": "1",
@@ -5029,14 +5030,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route royale (du pont de Brian'ch à Baldh-Ruoch)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829143804964",
         "faction_id": "15",
+        "guarded": "false",
         "id": "197",
         "itineraire": "",
         "map_id": "1",
@@ -5048,14 +5049,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier de Mambrun à Helefrt",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829144836802",
         "faction_id": "15",
+        "guarded": "false",
         "id": "198",
         "itineraire": "",
         "map_id": "1",
@@ -5067,14 +5068,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier vers les ruines du château des Mac Farquam",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829152942242",
         "faction_id": "15",
+        "guarded": "false",
         "id": "199",
         "itineraire": "",
         "map_id": "1",
@@ -5086,14 +5087,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie de l'Oëss (de Kermordhran à Kember)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829183619741",
         "faction_id": "11",
+        "guarded": "false",
         "id": "200",
         "itineraire": "",
         "map_id": "1",
@@ -5105,14 +5106,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Donir (du pont sur l'Oëss de Kember à Baldh-Ruoch)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829144449794",
         "faction_id": "15",
+        "guarded": "false",
         "id": "201",
         "itineraire": "",
         "map_id": "1",
@@ -5124,14 +5125,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Kreizhdour (de Telh au carrefour de Laräch)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829144354634",
         "faction_id": "15",
+        "guarded": "false",
         "id": "202",
         "itineraire": "",
         "map_id": "1",
@@ -5143,14 +5144,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Kreizhdour (du carrefour d'Helefrt à Telh)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829144538019",
         "faction_id": "15",
+        "guarded": "false",
         "id": "203",
         "itineraire": "",
         "map_id": "1",
@@ -5162,14 +5163,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Kreizhdour (du carrefour de Laräch à Arngyll)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829144214552",
         "faction_id": "15",
+        "guarded": "false",
         "id": "204",
         "itineraire": "",
         "map_id": "1",
@@ -5181,14 +5182,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Kreizhdour (du col de Siagal au carrefour d'Helefrt)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906133758467",
         "faction_id": "",
+        "guarded": "false",
         "id": "205",
         "itineraire": "",
         "map_id": "1",
@@ -5200,14 +5201,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Canal des marécages gris (de Tuaille au carrefour du sud de Déas)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
-        "created": "20150906134218571",
         "text": "",
         "categorie": "cartographie",
+        "created": "20150906134218571",
         "faction_id": "",
+        "guarded": "false",
         "id": "206",
         "itineraire": "",
         "map_id": "1",
@@ -5219,14 +5220,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Canal des marécages gris d'Ostreach",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906134123128",
         "faction_id": "",
+        "guarded": "false",
         "id": "207",
         "itineraire": "",
         "map_id": "1",
@@ -5238,14 +5239,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Canal des marécages gris de Cardach",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906134028194",
         "faction_id": "",
+        "guarded": "false",
         "id": "208",
         "itineraire": "",
         "map_id": "1",
@@ -5257,14 +5258,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Canal des marécages gris de Merieren",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906133918451",
         "faction_id": "",
+        "guarded": "false",
         "id": "209",
         "itineraire": "",
         "map_id": "1",
@@ -5276,14 +5277,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Canal des marécages gris de Tuaille",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "La Voie sainte relie la capitale gwidrite, Ard-Amrach, à la ville sainte de Fionnfuar.",
         "categorie": "cartographie",
         "created": "20150330135431438",
         "faction_id": "1",
+        "guarded": "false",
         "id": "21",
         "itineraire": "Voie sainte",
         "map_id": "1",
@@ -5294,14 +5295,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Voie sainte (d'Ard-Amrach à Nectan)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906134313032",
         "faction_id": "",
+        "guarded": "false",
         "id": "210",
         "itineraire": "",
         "map_id": "1",
@@ -5313,14 +5314,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Canal des marécages gris du sud de Déas",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906155810497",
         "faction_id": "15",
+        "guarded": "false",
         "id": "211",
         "itineraire": "",
         "map_id": "1",
@@ -5332,14 +5333,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin d'Osta-Baille au carrefour de Calhtair",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906132016411",
         "faction_id": "11",
+        "guarded": "false",
         "id": "212",
         "itineraire": "",
         "map_id": "1",
@@ -5351,14 +5352,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Cardach au carrefour du sud de Déas",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906132812821",
         "faction_id": "15",
+        "guarded": "false",
         "id": "213",
         "itineraire": "",
         "map_id": "1",
@@ -5370,14 +5371,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Diinthër à Rhingal",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906135620689",
         "faction_id": "15",
+        "guarded": "false",
         "id": "214",
         "itineraire": "",
         "map_id": "1",
@@ -5389,14 +5390,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Iolairnead au carrefour du Gouffre Carmin",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906133145842",
         "faction_id": "15",
+        "guarded": "false",
         "id": "215",
         "itineraire": "",
         "map_id": "1",
@@ -5408,14 +5409,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Kel Loar au carrefour d'Eschen",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906135530105",
         "faction_id": "15",
+        "guarded": "false",
         "id": "216",
         "itineraire": "",
         "map_id": "1",
@@ -5427,14 +5428,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Kell au carrefour du Gouffre Carmin",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906121724926",
         "faction_id": "15",
+        "guarded": "false",
         "id": "217",
         "itineraire": "",
         "map_id": "1",
@@ -5446,14 +5447,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Leacach au carrefour reizhite vers Aelwyd Saogh",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829144013715",
         "faction_id": "15",
+        "guarded": "false",
         "id": "218",
         "itineraire": "",
         "map_id": "1",
@@ -5465,14 +5466,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Mambrun au carrefour de l'adret des Gisants",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906155731277",
         "faction_id": "15",
+        "guarded": "false",
         "id": "219",
         "itineraire": "",
         "map_id": "1",
@@ -5484,14 +5485,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Smàrag au carrefour de Calhtair",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906134718318",
         "faction_id": "15",
+        "guarded": "false",
         "id": "220",
         "itineraire": "",
         "map_id": "1",
@@ -5503,14 +5504,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Terkhên au carrefour à l'est de Terkhên",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906120728310",
         "faction_id": "15",
+        "guarded": "false",
         "id": "221",
         "itineraire": "",
         "map_id": "1",
@@ -5522,14 +5523,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Thòl à Caiginn",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906133226664",
         "faction_id": "15",
+        "guarded": "false",
         "id": "222",
         "itineraire": "",
         "map_id": "1",
@@ -5541,14 +5542,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour d'Eschen à Seòl",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906132053516",
         "faction_id": "11",
+        "guarded": "false",
         "id": "223",
         "itineraire": "",
         "map_id": "1",
@@ -5560,14 +5561,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour de Còmhlan à Iolach",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906132508121",
         "faction_id": "11",
+        "guarded": "false",
         "id": "224",
         "itineraire": "",
         "map_id": "1",
@@ -5579,14 +5580,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour du sud de Déas au carrefour de Còmhlan",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906122038917",
         "faction_id": "15",
+        "guarded": "false",
         "id": "225",
         "itineraire": "",
         "map_id": "1",
@@ -5598,14 +5599,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour reizhite au carrefour gwidrite d'Alwyd Saogh",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829202813818",
         "faction_id": "15",
+        "guarded": "false",
         "id": "226",
         "itineraire": "",
         "map_id": "1",
@@ -5617,14 +5618,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du Gué Sanglant au carrefour entre Corvus et Kermordhran",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Après cinq siècles d'abandon, la route qui permettait au roi de Gwidre de se rendre à la citadelle d'Aelwyd Saogh n'est plus guère qu'un chemin que le temps et les éléments peuvent avoir rendu hasardeux.",
         "categorie": "cartographie",
         "created": "20150406215115144",
         "faction_id": "15",
+        "guarded": "false",
         "id": "227",
         "map_id": "1",
         "markerend_id": "80",
@@ -5634,14 +5635,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin gwidrite vers Aelwyd Saogh",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906140926032",
         "faction_id": "15",
+        "guarded": "false",
         "id": "228",
         "itineraire": "",
         "map_id": "1",
@@ -5653,14 +5654,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin reizhite de Corvus à Kermordhran",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Après cinq siècles d'abandon, la route qui permettait au roi de Reizh de se rendre à la citadelle d'Aelwyd Saogh n'est plus guère qu'un chemin que le temps et les éléments peuvent avoir rendu hasardeux.",
         "categorie": "cartographie",
         "created": "20150406215106654",
         "faction_id": "15",
+        "guarded": "false",
         "id": "229",
         "map_id": "1",
         "markerend_id": "80",
@@ -5670,14 +5671,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin reizhite vers Aelwyd Saogh",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "La Voie sainte relie la capitale gwidrite, Ard-Amrach, à la ville sainte de Fionnfuar.",
         "categorie": "cartographie",
         "created": "20150330135537466",
         "faction_id": "1",
+        "guarded": "false",
         "id": "23",
         "itineraire": "Voie sainte",
         "map_id": "1",
@@ -5688,14 +5689,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Voie sainte (de Nectan à Gouvran)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Après cinq siècles d'abandon, la route qui permettait au roi de Taol-Kaer de se rendre à la citadelle d'Aelwyd Saogh n'est plus guère qu'un chemin que le temps et les éléments peuvent avoir rendu hasardeux.",
         "categorie": "cartographie",
         "created": "20150829143645055",
         "faction_id": "15",
+        "guarded": "false",
         "id": "230",
         "itineraire": "",
         "map_id": "1",
@@ -5707,14 +5708,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin talkéride vers Aelwyd Saogh (d'Ard-Monach au col de Brorann)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Après cinq siècles d'abandon, la route qui permettait au roi de Taol-Kaer de se rendre à la citadelle d'Aelwyd Saogh n'est plus guère qu'un chemin que le temps et les éléments peuvent avoir rendu hasardeux.",
         "categorie": "cartographie",
         "created": "20150406214104526",
         "faction_id": "15",
+        "guarded": "false",
         "id": "231",
         "map_id": "1",
         "markerend_id": "80",
@@ -5724,14 +5725,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin talkéride vers Aelwyd Saogh (du col de Brorann à Aelwyd Saogh)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906132205964",
         "faction_id": "3",
+        "guarded": "false",
         "id": "232",
         "itineraire": "",
         "map_id": "1",
@@ -5743,14 +5744,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers Còmhlan",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150829150655002",
         "faction_id": "15",
+        "guarded": "false",
         "id": "233",
         "itineraire": "",
         "map_id": "1",
@@ -5762,14 +5763,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Gwidre (du Gué Sanglant à l'abbaye de Corvus)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906140416280",
         "faction_id": "15",
+        "guarded": "false",
         "id": "234",
         "itineraire": "",
         "map_id": "1",
@@ -5781,14 +5782,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route marine (du Clos-des-Cendres au carrefour des Cendres)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906135012864",
         "faction_id": "1",
+        "guarded": "false",
         "id": "235",
         "itineraire": "",
         "map_id": "1",
@@ -5800,14 +5801,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier côtier de Calvaire (de Saint Arpan à Sainte Nihesk)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906135154886",
         "faction_id": "1",
+        "guarded": "false",
         "id": "236",
         "itineraire": "",
         "map_id": "1",
@@ -5819,14 +5820,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier côtier de Calvaire (de Saint Heskenen à Saint Persked)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906135112694",
         "faction_id": "1",
+        "guarded": "false",
         "id": "237",
         "itineraire": "",
         "map_id": "1",
@@ -5838,14 +5839,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier côtier de Calvaire (de Sainte Nihesk à Saint Heskenen)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906135352256",
         "faction_id": "1",
+        "guarded": "false",
         "id": "238",
         "itineraire": "",
         "map_id": "1",
@@ -5857,14 +5858,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier côtier de Calvaire (du phare sud à Saint Arpan)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906141123924",
         "faction_id": "15",
+        "guarded": "false",
         "id": "239",
         "itineraire": "",
         "map_id": "1",
@@ -5876,14 +5877,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier de Frendian à Osta-Baille",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "La Voie sainte relie la capitale gwidrite, Ard-Amrach, à la ville sainte de Fionnfuar.",
         "categorie": "cartographie",
         "created": "20150330135625919",
         "faction_id": "1",
+        "guarded": "false",
         "id": "24",
         "itineraire": "Voie sainte",
         "map_id": "1",
@@ -5894,14 +5895,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Voie sainte (de Gouvran à Deh'ad)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906135713087",
         "faction_id": "4",
+        "guarded": "false",
         "id": "240",
         "itineraire": "",
         "map_id": "1",
@@ -5913,14 +5914,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier de la source aux Fols",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906155937321",
         "faction_id": "15",
+        "guarded": "false",
         "id": "241",
         "itineraire": "",
         "map_id": "1",
@@ -5932,14 +5933,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier du carrefour de Calhtair et Kaer Daegis",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150906133101741",
         "faction_id": "15",
+        "guarded": "false",
         "id": "242",
         "itineraire": "",
         "map_id": "1",
@@ -5951,14 +5952,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier vers l'îlot d'Eschen",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150322085917520",
         "faction_id": "15",
+        "guarded": "false",
         "id": "25",
         "itineraire": "",
         "map_id": "1",
@@ -5969,14 +5970,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Gwidre (du château des Mac Emmanon au Gué Sanglant)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150330135955989",
         "faction_id": "11",
+        "guarded": "false",
         "id": "26",
         "itineraire": "Route royale (itinéraire)",
         "map_id": "1",
@@ -5987,14 +5988,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route royale (de la demeure des Mac Baellec au carrefour de Promesse)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Les seigneurs du Croissant d'Émeraude imposent de nombreuses taxes le long de cette route, et ils n'hésitent pas à infliger des vexations aux voyageurs liées à la couronne reizhite, aussi bien marchands que magientistes.",
         "categorie": "cartographie",
         "created": "20150330140341240",
         "faction_id": "11",
+        "guarded": "false",
         "id": "27",
         "map_id": "1",
         "markerend_id": "98",
@@ -6004,14 +6005,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de la côte d'Émeraude (du carrefour de l'entrée du Reizh à Nua Caladh)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150330140617035",
         "faction_id": "13",
+        "guarded": "false",
         "id": "28",
         "map_id": "1",
         "markerend_id": "34",
@@ -6021,14 +6022,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Ouest (de Kalvernach à Crail)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Cette route est très fréquentée par les chevaliers hilderins, notamment entre Osta-Baille et Ard-Monach. Au-delà, vers Caiginn, la route n'est pas toujours pavée.",
         "categorie": "cartographie",
         "created": "20150305155218157",
         "faction_id": "14",
+        "guarded": "false",
         "id": "29",
         "itineraire": "Route des Hilderins",
         "map_id": "1",
@@ -6039,14 +6040,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Route des Hilderins (du carrefour de Frendian à Caiginn)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150330140740577",
         "faction_id": "15",
+        "guarded": "false",
         "id": "30",
         "map_id": "1",
         "markerend_id": "161",
@@ -6056,14 +6057,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du Grand Est (de Farl au carrefour de Gleb)",
-        "zoneparent_id": "57",
-        "guarded": "false"
+        "zoneparent_id": "57"
     },
     {
         "text": "La longue piste qui mène au col de Gaos-Bodhar n'est pas entretenue, et ce voyage aux confins de la péninsule vers le Continent est aussi ardu que périlleux.",
         "categorie": "cartographie",
         "created": "20150330141021384",
         "faction_id": "15",
+        "guarded": "false",
         "id": "32",
         "map_id": "1",
         "markerend_id": "40",
@@ -6073,14 +6074,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Piste de l'ours blanc",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Bien que ce village pourrait être une étape sur les routes maritimes commerciales qui longent prudemment les côtes, les navigateurs évitent de relâcher à Aimliù dont les habitants ont sinistre réputation.",
         "categorie": "cartographie",
         "created": "20150428204739148",
         "faction_id": "4",
+        "guarded": "false",
         "id": "33",
         "map_id": "1",
         "markerend_id": "9",
@@ -6090,14 +6091,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Aimliù - Ard-Amrach",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Les capitaines qui assurent cette liaison commerciale prennent garde à longer les côtes pour ne pas braver les flots déchaînés de l'Océan Furieux.",
         "categorie": "cartographie",
         "created": "20150428205539823",
         "faction_id": "4",
+        "guarded": "false",
         "id": "34",
         "map_id": "1",
         "markerend_id": "25",
@@ -6107,14 +6108,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Ard-Amrach - Gouvran",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Le Clos-des-Cendres étant une ville dont l'existence sort petit à petit du secret, elle figure sur peu de cartes et toutes les voies maritimes n'y font pas escale. Il est assez fréquent qu'une banquise se forme en hiver.",
         "categorie": "cartographie",
         "created": "20150428211820353",
         "faction_id": "4",
+        "guarded": "false",
         "id": "35",
         "map_id": "1",
         "markerend_id": "139",
@@ -6124,14 +6125,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Clos-des-Cendres - Farl",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Les capitaines qui ont des relations à Ear Caladh, dont les taxes portuaires sont moins élevées qu'à son nouveau voisin, privilégient cette liaison commerciale, assurée par des koggens à la belle saison, quelquefois jusqu'en automne. Aux abords de l'embouchure du Tealderoth, les marins se méfient des sirènes auxquelles sont attribuées des disparitions régulières.",
         "categorie": "cartographie",
         "created": "20150425075356206",
         "faction_id": "4",
+        "guarded": "false",
         "id": "36",
         "map_id": "1",
         "markerend_id": "11",
@@ -6141,14 +6142,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Ear Caladh - Embouchure du Tealderoth",
-        "zoneparent_id": "36",
-        "guarded": "false"
+        "zoneparent_id": "36"
     },
     {
         "text": "Les capitaines qui assurent cette liaison commerciale prennent garde à longer les côtes pour ne pas braver les flots déchaînés de l'Océan Furieux.",
         "categorie": "cartographie",
         "created": "20150428202719194",
         "faction_id": "4",
+        "guarded": "false",
         "id": "37",
         "map_id": "1",
         "markerend_id": "45",
@@ -6158,14 +6159,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Embouchure du Kreizhdour - Gorm Caladh",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Des koggens assurent régulièrement cette liaison commerciale, mais seulement à la belle saison, quelquefois jusqu'en automne. Aux abords de l'embouchure du Tealderoth, les marins se méfient des sirènes auxquelles sont attribuées des disparitions régulières.",
         "categorie": "cartographie",
         "created": "20150425073828628",
         "faction_id": "4",
+        "guarded": "false",
         "id": "38",
         "map_id": "1",
         "markerend_id": "73",
@@ -6175,14 +6176,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Embouchure du Tealderoth - Kel Loar",
-        "zoneparent_id": "36",
-        "guarded": "false"
+        "zoneparent_id": "36"
     },
     {
         "text": "Le Clos-des-Cendres étant une ville dont l'existence sort petit à petit du secret, elle figure sur peu de cartes et toutes les voies maritimes n'y font pas escale. Il est assez fréquent qu'une banquise se forme en hiver.",
         "categorie": "cartographie",
         "created": "20150428211007359",
         "faction_id": "4",
+        "guarded": "false",
         "id": "39",
         "map_id": "1",
         "markerend_id": "19",
@@ -6192,14 +6193,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Fionnfuar - Clos-des-Cendres",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Cette route pavée relie l'ancienne capitale, Tuaille, à la nouvelle, Osta-Baille. Entretenue tant bien que mal par la guilde des Paveurs, elle traverse les marécages gris et passe par la ville de Merieren, à l'embouchure du Klaedhin. Elle est très fréquentée par les voyageurs et les caravanes, bien que ceux qui peuvent se le payer préfèrent naviguer sur le cours tranquille du fleuve.",
         "categorie": "cartographie",
         "created": "20150318164432547",
         "faction_id": "13",
+        "guarded": "false",
         "id": "4",
         "itineraire": "Route des capitales",
         "map_id": "1",
@@ -6210,14 +6211,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Route des capitales (de Tuaille à Merieren)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Les capitaines qui assurent cette liaison commerciale prennent garde à longer les côtes pour ne pas braver les flots déchaînés de l'Océan Furieux. Le Clos-des-Cendres étant une ville dont l'existence sort petit à petit du secret, elle figure sur peu de cartes et toutes les voies maritimes n'y font pas escale. Il est assez fréquent qu'une banquise se forme en hiver.",
         "categorie": "cartographie",
         "created": "20150720175451224",
         "faction_id": "4",
+        "guarded": "false",
         "id": "40",
         "map_id": "1",
         "markerend_id": "139",
@@ -6227,14 +6228,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Fionnfuar - Farl",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Bien que ce village pourrait être une étape sur les routes maritimes commerciales qui longent prudemment les côtes, les navigateurs évitent de relâcher à Aimliù dont les habitants ont sinistre réputation.",
         "categorie": "cartographie",
         "created": "20150428205101523",
         "faction_id": "4",
+        "guarded": "false",
         "id": "41",
         "map_id": "1",
         "markerend_id": "10",
@@ -6244,14 +6245,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Gorm Caladh - Aimliù",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Les capitaines qui assurent cette liaison commerciale prennent garde à longer les côtes pour ne pas braver les flots déchaînés de l'Océan Furieux, et évitent de relâcher à Aimliù dont les habitants ont sinistre réputation.",
         "categorie": "cartographie",
         "created": "20150428203411398",
         "faction_id": "4",
+        "guarded": "false",
         "id": "42",
         "map_id": "1",
         "markerend_id": "9",
@@ -6261,14 +6262,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Gorm Caladh - Ard-Amrach",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Les capitaines qui assurent cette liaison commerciale prennent garde à longer les côtes pour ne pas braver les flots déchaînés de l'Océan Furieux. Lors des hivers les plus froids, une banquise peut se former.",
         "categorie": "cartographie",
         "created": "20150428210234616",
         "faction_id": "4",
+        "guarded": "false",
         "id": "43",
         "map_id": "1",
         "markerend_id": "20",
@@ -6278,14 +6279,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Gouvran - Fionnfuar",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Des koggens assurent régulièrement cette liaison commerciale, mais seulement à la belle saison, quelquefois jusqu'en automne.",
         "categorie": "cartographie",
         "created": "20150425082300311",
         "faction_id": "4",
+        "guarded": "false",
         "id": "44",
         "map_id": "1",
         "markerend_id": "72",
@@ -6295,14 +6296,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Kel Loar - Seòl",
-        "zoneparent_id": "36",
-        "guarded": "false"
+        "zoneparent_id": "36"
     },
     {
         "text": "Les bateaux qui empruntent cette liaison maritime sont peu nombreux.",
         "categorie": "cartographie",
         "created": "20150425131147831",
         "faction_id": "4",
+        "guarded": "false",
         "id": "45",
         "map_id": "1",
         "markerend_id": "7",
@@ -6312,14 +6313,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Koskan - Tuaille",
-        "zoneparent_id": "36",
-        "guarded": "false"
+        "zoneparent_id": "36"
     },
     {
         "text": "Cette voie maritime permet au duché de Tulg d'exporter ses ressources minières et son bois. Le phare de Tulg Naomh est un point de repère très connu pour les navigateurs.",
         "categorie": "cartographie",
         "created": "20150428195946765",
         "faction_id": "4",
+        "guarded": "false",
         "id": "46",
         "map_id": "1",
         "markerend_id": "47",
@@ -6329,14 +6330,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Llewellen - Tulg Naomh",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Bien que plus lourdement taxée qu'à l'ancien port d'Ear Caladh devenu trop petit, cette liaison commerciale est la plus fréquente. Elle n'est assurée par des koggens qu'à la belle saison, quelquefois jusqu'en automne. Aux abords de l'embouchure du Tealderoth, les marins se méfient des sirènes auxquelles sont attribuées des disparitions régulières.",
         "categorie": "cartographie",
         "created": "20150425080824539",
         "faction_id": "4",
+        "guarded": "false",
         "id": "47",
         "map_id": "1",
         "markerend_id": "11",
@@ -6346,14 +6347,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Nua Caladh - Embouchure du Tealderoth",
-        "zoneparent_id": "36",
-        "guarded": "false"
+        "zoneparent_id": "36"
     },
     {
         "text": "Seuls les plus gros chargements de fret sont encore transportés par cette voie maritime, qui est concurrencée par les chars à voile qui acheminent bien plus rapidement et sûrement les passagers et les marchandises plus légères à travers les Grandes Plages.",
         "categorie": "cartographie",
         "created": "20150425124935882",
         "faction_id": "4",
+        "guarded": "false",
         "id": "48",
         "map_id": "1",
         "markerend_id": "105",
@@ -6363,14 +6364,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Seòl - Smàrag",
-        "zoneparent_id": "36",
-        "guarded": "false"
+        "zoneparent_id": "36"
     },
     {
         "text": "Seuls les plus gros chargements de fret sont encore transportés par cette voie maritime, qui est concurrencée par les chars à voile qui acheminent bien plus rapidement et sûrement les passagers et les marchandises plus légères à travers les Grandes Plages.",
         "categorie": "cartographie",
         "created": "20150425125837120",
         "faction_id": "4",
+        "guarded": "false",
         "id": "49",
         "map_id": "1",
         "markerend_id": "63",
@@ -6380,14 +6381,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Smàrag - Koskan",
-        "zoneparent_id": "36",
-        "guarded": "false"
+        "zoneparent_id": "36"
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150330132747983",
         "faction_id": "",
+        "guarded": "false",
         "id": "5",
         "map_id": "1",
         "markerend_id": "14",
@@ -6397,14 +6398,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Nord du Pont de l'Alliance",
-        "zoneparent_id": "57",
-        "guarded": "false"
+        "zoneparent_id": "57"
     },
     {
         "text": "Rares sont les bateaux qui naviguent jusqu'à Iolach, ce port de pêche ayant mauvaise réputation.",
         "categorie": "cartographie",
         "created": "20150425133525120",
         "faction_id": "4",
+        "guarded": "false",
         "id": "50",
         "map_id": "1",
         "markerend_id": "78",
@@ -6414,14 +6415,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Tuaille - Iolach",
-        "zoneparent_id": "36",
-        "guarded": "false"
+        "zoneparent_id": "36"
     },
     {
         "text": "Cette voie maritime permet au duché de Tulg d'exporter ses ressources minières et son bois. Le phare de Tulg Naomh est un point de repère très connu pour les navigateurs.",
         "categorie": "cartographie",
         "created": "20150428202334024",
         "faction_id": "4",
+        "guarded": "false",
         "id": "51",
         "map_id": "1",
         "markerend_id": "93",
@@ -6431,14 +6432,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison Tulg Naomh - Embouchure du Kreizhdour",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Rejoindre Calvaire ne peut se faire qu'en caraque à la fin de l'été, en profitant dans les derniers jours de Lunasdal d'un puissant courant maritime depuis l'embouchure du Pezhdour vers le nord-ouest. À condition que le capitaine parvienne à mettre son navire sous le vent qui lui permettra de sortir du courant et d'accoster sur la pointe nord de l'île, sous peine de se diriger irrémédiablement vers le grand large !",
         "categorie": "cartographie",
         "created": "20150713080221951",
         "faction_id": "1",
+        "guarded": "false",
         "id": "52",
         "itineraire": "Liaison vers Calvaire",
         "map_id": "1",
@@ -6449,14 +6450,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de l'embouchure du Pezhdour au Roc)",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Si le capitaine de la caraque est parvenu sortir du courant vers le grand large pour rejoindre la pointe nord de l'île du Calvaire, il doit ensuite longer toute la côte ouest de l'île en évitant les écueils avant de pouvoir enfin passer la pointe sud et rejoindre des eaux relativement plus clémentes.",
         "categorie": "cartographie",
         "created": "20150523105009981",
         "faction_id": "1",
+        "guarded": "false",
         "id": "53",
         "itineraire": "Liaison vers Calvaire",
         "map_id": "1",
@@ -6467,14 +6468,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de la pointe ouest à la pointe sud)",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Depuis les eaux relativement plus clémentes de la côte est de l'île, il est possible de rallier les quatre villages-monastères et de revenir sur la péninsule vers Gorm Caladh.",
         "categorie": "cartographie",
         "created": "20150523111710463",
         "faction_id": "1",
+        "guarded": "false",
         "id": "54",
         "itineraire": "Liaison vers Calvaire",
         "map_id": "1",
@@ -6485,14 +6486,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de la pointe sud à Gorm Caladh)",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Une fois passée la pointe sud les eaux sont relativement plus clémentes. De là, il est possible de rallier les quatre villages-monastères et de revenir sur la péninsule vers Gorm Caladh.",
         "categorie": "cartographie",
         "created": "20150523111644476",
         "faction_id": "1",
+        "guarded": "false",
         "id": "55",
         "itineraire": "Liaison vers Calvaire",
         "map_id": "1",
@@ -6503,13 +6504,13 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de la pointe sud à Saint Arpan)",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Une fois passée la pointe sud les eaux sont relativement plus clémentes. De là, il est possible de rallier les quatre villages-monastères et de revenir sur la péninsule vers Gorm Caladh.",
         "categorie": "cartographie",
         "faction_id": "1",
+        "guarded": "false",
         "id": "56",
         "itineraire": "Liaison vers Calvaire",
         "map_id": "1",
@@ -6520,13 +6521,13 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de Saint Arpan à Sainte Nihesk)",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Une fois passée la pointe sud les eaux sont relativement plus clémentes. De là, il est possible de rallier les quatre villages-monastères et de revenir sur la péninsule vers Gorm Caladh.",
         "categorie": "cartographie",
         "faction_id": "1",
+        "guarded": "false",
         "id": "57",
         "itineraire": "Liaison vers Calvaire",
         "map_id": "1",
@@ -6537,13 +6538,13 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de Saint Heskenen à Saint Persked)",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Une fois passée la pointe sud les eaux sont relativement plus clémentes. De là, il est possible de rallier les quatre villages-monastères et de revenir sur la péninsule vers Gorm Caladh.",
         "categorie": "cartographie",
         "faction_id": "1",
+        "guarded": "false",
         "id": "58",
         "itineraire": "Liaison vers Calvaire",
         "map_id": "1",
@@ -6554,14 +6555,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de Sainte Nihesk à Saint Heskenen)",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Si le capitaine de la caraque est parvenu sortir du courant vers le grand large pour rejoindre la pointe nord de l'île du Calvaire, il doit ensuite longer toute la côte ouest de l'île en évitant les écueils avant de pouvoir enfin passer la pointe sud et rejoindre des eaux relativement plus clémentes.",
         "categorie": "cartographie",
         "created": "20150523101512060",
         "faction_id": "1",
+        "guarded": "false",
         "id": "59",
         "itineraire": "Liaison vers Calvaire",
         "map_id": "1",
@@ -6572,14 +6573,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (du Roc à la pointe ouest)",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Ce chemin mène au promontoire où se trouve le sanctuaire demorthèn du \"belvédère de l'est\".",
         "categorie": "cartographie",
         "created": "20150330132944980",
         "faction_id": "3",
+        "guarded": "false",
         "id": "6",
         "map_id": "1",
         "markerend_id": "12",
@@ -6589,14 +6590,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Chemin vers Fairean Ear",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "La navigation vers les îles de l'archipel peut être compliquée par les conditions climatiques, oscillant fréquemment entre le froid hivernal et les diverses émanations volcaniques.",
         "categorie": "cartographie",
         "created": "20150524070252112",
         "faction_id": "2",
+        "guarded": "false",
         "id": "60",
         "itineraire": "",
         "map_id": "1",
@@ -6607,14 +6608,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers l'Archipel des Cendres (depuis Clos-des-Cendres)",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "La navigation vers les îles de l'archipel peut être compliquée par les conditions climatiques, oscillant fréquemment entre le froid hivernal et les diverses émanations volcaniques.",
         "categorie": "cartographie",
         "created": "20150524071109886",
         "faction_id": "1",
+        "guarded": "false",
         "id": "61",
         "itineraire": "",
         "map_id": "1",
@@ -6625,14 +6626,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers l'Archipel des Cendres (depuis Fionnfuar)",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Comme l'île est bordée de récifs, la seule période favorable pour y accoster est au début de l'été, entre la mi-Ogmhios et la fin de Luchar, quand les courants sont plus stables. Le reste de l'année, seuls quelques passeurs de Koskan, des fous qui disent s'être abreuvés à la source aux Fols, acceptent de faire la traversée.",
         "categorie": "cartographie",
         "created": "20150425140351062",
         "faction_id": "4",
+        "guarded": "false",
         "id": "62",
         "map_id": "1",
         "markerend_id": "103",
@@ -6642,14 +6643,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers l'île aux Cairns",
-        "zoneparent_id": "36",
-        "guarded": "false"
+        "zoneparent_id": "36"
     },
     {
         "text": "La traversée vers l'archipel des Trois Sœurs s'effectue en caraque, et seulement à la belle saison et par temps clair, à cause des hauts-fonds. L'accostage ne peut se faire que sur la côte occidentale de l'île de Tir na Loch, où se trouve le port de Màn Atlach destiné aux échanges entre les Tri-Kazeliens et les îliens.",
         "categorie": "cartographie",
         "created": "20150425144231846",
         "faction_id": "4",
+        "guarded": "false",
         "id": "63",
         "map_id": "1",
         "markerend_id": "95",
@@ -6659,14 +6660,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers les Tri-Sweszörs",
-        "zoneparent_id": "36",
-        "guarded": "false"
+        "zoneparent_id": "36"
     },
     {
         "text": "La traversée de Farl vers Mornegivre, sur l'océan Furieux où les tempêtes glaciales sont fréquentes, est par nature incertaine, et rares sont les capitaines qui accepteront d'y risquer leur caraque.",
         "categorie": "cartographie",
         "created": "20150416124030385",
         "faction_id": "4",
+        "guarded": "false",
         "id": "64",
         "map_id": "1",
         "markerend_id": "104",
@@ -6676,14 +6677,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Mornegivre",
-        "zoneparent_id": "40",
-        "guarded": "false"
+        "zoneparent_id": "40"
     },
     {
         "text": "Cette route pavée relie l'ancienne capitale, Tuaille, à la nouvelle, Osta-Baille. Entretenue tant bien que mal par la guilde des Paveurs, elle passe par Merieren, à l'embouchure du Klaedhin. Elle est très fréquentée par les voyageurs et les caravanes, bien que ceux qui peuvent se le payer préfèrent naviguer sur le cours tranquille du fleuve.",
         "categorie": "cartographie",
         "created": "20150528122134409",
         "faction_id": "13",
+        "guarded": "false",
         "id": "65",
         "itineraire": "Route des capitales",
         "map_id": "1",
@@ -6694,14 +6695,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Route des capitales (de Merieren à Osta-Baille)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Cette route est très fréquentée par les chevaliers hilderins, notamment entre Osta-Baille et Ard-Monach. Des brigands sévissent parfois autour de cette dernière. Au-delà, vers Caiginn, la route n'est pas toujours pavée.",
         "categorie": "cartographie",
         "created": "20150529071756111",
         "faction_id": "14",
+        "guarded": "false",
         "id": "66",
         "itineraire": "Route des Hilderins",
         "map_id": "1",
@@ -6712,14 +6713,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Route des Hilderins (d'Ard-Monach au carrefour de Frendian)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Cette route est très fréquentée par les chevaliers hilderins, notamment entre Osta-Baille et Ard-Monach.",
         "categorie": "cartographie",
         "created": "20150424084419154",
         "faction_id": "14",
+        "guarded": "false",
         "id": "67",
         "itineraire": "Route des Hilderins",
         "map_id": "1",
@@ -6730,14 +6731,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Route des Hilderins (d'Osta-Baille à Mùdan)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Cette route est très fréquentée par les chevaliers hilderins, notamment entre Osta-Baille et Ard-Monach. Des brigands sévissent parfois autour de cette dernière.",
         "categorie": "cartographie",
         "created": "20150423113439110",
         "faction_id": "14",
+        "guarded": "false",
         "id": "68",
         "itineraire": "Route des Hilderins",
         "map_id": "1",
@@ -6748,14 +6749,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Route des Hilderins (de Mùdan à Ard-Monach)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150528144647059",
         "faction_id": "11",
+        "guarded": "false",
         "id": "69",
         "itineraire": "",
         "map_id": "1",
@@ -6766,14 +6767,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier vers la pointe de Hòb",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150330133151418",
         "faction_id": "",
+        "guarded": "false",
         "id": "7",
         "map_id": "1",
         "markerend_id": "14",
@@ -6783,14 +6784,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Kalvernach est",
-        "zoneparent_id": "57",
-        "guarded": "false"
+        "zoneparent_id": "57"
     },
     {
         "text": "Des embarcations traversent l'embouchure du Donir, pour permettre notamment aux travailleurs du nouveau port, Nua Caladh, de se rendre à l'ancien port, Ear Caladh.",
         "categorie": "cartographie",
         "created": "20150428185147199",
         "faction_id": "4",
+        "guarded": "false",
         "id": "70",
         "map_id": "1",
         "markerend_id": "98",
@@ -6800,14 +6801,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Traversée Ear Caladh - Nua Caladh",
-        "zoneparent_id": "36",
-        "guarded": "false"
+        "zoneparent_id": "36"
     },
     {
         "text": "Cette route relie Expiation, l'un des principaux lieux de pèlerinage du royaume de Gwidre, à la capitale. Ce voyage, ponctué de monastères, est l'occasion de se purifier avant d'arriver à Ard-Amrach pour y participer à des cérémonies rituelles. C'est l'une des rares routes bien entretenues qui permettent de traverser en relative sécurité les dangereuses Mòr Roimh.",
         "categorie": "cartographie",
         "created": "20150529123414737",
         "faction_id": "1",
+        "guarded": "false",
         "id": "71",
         "itineraire": "Voie des pèlerins",
         "map_id": "1",
@@ -6818,14 +6819,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Voie des pèlerins (d'Expiation au carrefour du pic Ordachaï)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Cette route relie Expiation, l'un des principaux lieux de pèlerinage du royaume de Gwidre, à la capitale. Ce voyage, ponctué de monastères, est l'occasion de se purifier avant d'arriver à Ard-Amrach pour y participer à des cérémonies rituelles.",
         "categorie": "cartographie",
         "created": "20150408212054465",
         "faction_id": "1",
+        "guarded": "false",
         "id": "72",
         "itineraire": "Voie des pèlerins",
         "map_id": "1",
@@ -6836,14 +6837,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Voie des pèlerins (de Rhingal à Ard-Amrach)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331120557541",
         "faction_id": "15",
+        "guarded": "false",
         "id": "73",
         "itineraire": "",
         "map_id": "1",
@@ -6854,14 +6855,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour de l'adret des Gisants à Expiation",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Cette route relie Expiation, l'un des principaux lieux de pèlerinage du royaume de Gwidre, à la capitale. Ce voyage, ponctué de monastères, est l'occasion de se purifier avant d'arriver à Ard-Amrach pour y participer à des cérémonies rituelles. C'est l'une des rares routes bien entretenues qui permettent de traverser en relative sécurité les dangereuses Mòr Roimh.",
         "categorie": "cartographie",
         "created": "20150331120443326",
         "faction_id": "1",
+        "guarded": "false",
         "id": "74",
         "itineraire": "Voie des pèlerins",
         "map_id": "1",
@@ -6872,14 +6873,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Voie des pèlerins (du carrefour du pic Ordachaï au carrefour du pic Venteux)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Cette route relie Expiation, l'un des principaux lieux de pèlerinage du royaume de Gwidre, à la capitale. Ce voyage, ponctué de monastères, est l'occasion de se purifier avant d'arriver à Ard-Amrach pour y participer à des cérémonies rituelles. C'est l'une des rares routes bien entretenues qui permettent de traverser en relative sécurité les dangereuses Mòr Roimh.",
         "categorie": "cartographie",
         "created": "20150331120308623",
         "faction_id": "1",
+        "guarded": "false",
         "id": "75",
         "itineraire": "Voie des pèlerins",
         "map_id": "1",
@@ -6890,14 +6891,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Voie des pèlerins (du carrefour du pic Venteux à Rhingal)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Ce chemin tortueux et abrupt permet de rejoindre la communauté autarcique de Haut-Mùdan. Il est surveillé de près et ses alentours sont piégés.",
         "categorie": "cartographie",
         "created": "20150424084435837",
         "faction_id": "3",
+        "guarded": "false",
         "id": "76",
         "map_id": "1",
         "markerend_id": "61",
@@ -6907,14 +6908,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Chemin de Mùdan au Haut-Mùdan",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Ce chemin permet de rejoindre Frendian depuis la route des Hilderins. Lorsque l'on pénètre dans le comté, les montagnes aux bois sombres s'ouvrent sur une vallée lumineuse et sereine.",
         "categorie": "cartographie",
         "created": "20150331125634223",
         "faction_id": "15",
+        "guarded": "false",
         "id": "77",
         "map_id": "1",
         "markerend_id": "56",
@@ -6924,14 +6925,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Chemin vers Frendian (depuis la route des Hilderins)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Cette route relie Kermordhran au Clos-des-Cendres. Des angardes bien entretenues la jalonnent, et des patrouilles la parcourent régulièrement.",
         "categorie": "cartographie",
         "created": "20150604083457642",
         "faction_id": "2",
+        "guarded": "false",
         "id": "78",
         "itineraire": "Route de la mer",
         "map_id": "1",
@@ -6942,14 +6943,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de la mer (du carrefour du cirque d'Argoneskan au carrefour des Cendres)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "La Voie sainte relie la capitale gwidrite, Ard-Amrach, à la ville sainte de Fionnfuar.",
         "categorie": "cartographie",
         "created": "20150603121135115",
         "faction_id": "1",
+        "guarded": "false",
         "id": "79",
         "itineraire": "Voie sainte",
         "map_id": "1",
@@ -6960,14 +6961,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Voie sainte (de Deh'ad à Fionnfuar)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Les deux ponts de Kember, nœuds de la stratégie royale pour le contrôle des infrastructures de transport, se rejoignent sur une vaste place de marché, encore en terre battue pour le moment.",
         "categorie": "cartographie",
         "created": "20150330133519582",
         "faction_id": "",
+        "guarded": "false",
         "id": "8",
         "map_id": "1",
         "markerend_id": "17",
@@ -6977,14 +6978,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Routes de Kember",
-        "zoneparent_id": "2",
-        "guarded": "false"
+        "zoneparent_id": "2"
     },
     {
         "text": "Ce chemin permet de joindre Nectan à Deh'ad. Moins utilisé que la célèbre Voie sainte, il suit la lisière entre la forêt du Dorchwald et les contreforts des Mòr Roimh.",
         "categorie": "cartographie",
         "created": "20150603121102874",
         "faction_id": "15",
+        "guarded": "false",
         "id": "80",
         "itineraire": "Route du Dorchwald",
         "map_id": "1",
@@ -6995,14 +6996,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Route du Dorchwald (de Lenbach au carrefour de Corvus)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Ce chemin est le plus sûr permettant de relier Kell et Kermordhran à travers les montagnes hostiles. Tout le long de la piste, des clascadh, d'anciens abris en pierre en forme de dôme, permettent aux voyageurs de s'abriter du vent et du froid.",
         "categorie": "cartographie",
         "created": "20150331114043182",
         "faction_id": "15",
+        "guarded": "false",
         "id": "81",
         "itineraire": "Route Grise",
         "map_id": "1",
@@ -7013,14 +7014,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Route Grise (de Kell au Château des Nevermore)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Ce chemin est le plus sûr permettant de relier Kell et Kermordhran à travers les montagnes hostiles. Tout le long de la piste, des clascadh, d'anciens abris en pierre en forme de dôme, permettent aux voyageurs de s'abriter du vent et du froid.",
         "categorie": "cartographie",
         "created": "20150602095952735",
         "faction_id": "15",
+        "guarded": "false",
         "id": "82",
         "itineraire": "Route Grise",
         "map_id": "1",
@@ -7031,14 +7032,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Route Grise (du Château des Nevermore à Kermordhran)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Le sentier qui mène à l'adret des Gisants est interdit par des pancartes posées par les sigires. Les varigaux, prévenus par des stermerks, n'y montent plus, laissant leurs clients finir seuls l'ascension. Si le sentier est souvent environné de brumes, un temps ensoleillé révèle les ossements de tous ceux morts là.",
         "categorie": "cartographie",
         "created": "20150402091531181",
         "faction_id": "15",
+        "guarded": "false",
         "id": "83",
         "map_id": "1",
         "markerend_id": "107",
@@ -7048,14 +7049,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Sentier de l'adret des Gisants",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Ni demorthèn ni fidèles du Temple n'empruntent plus cet ancien chemin depuis la destruction du liagcal et l'abandon de l'église qui l'avait remplacé. Des stermerks, les signes utilisés par les varigaux, préviennent ces derniers des dangers du lieu.",
         "categorie": "cartographie",
         "created": "20150603125205372",
         "faction_id": "15",
+        "guarded": "false",
         "id": "84",
         "itineraire": "",
         "map_id": "1",
@@ -7066,14 +7067,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Sentier des Pierres Brisées",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Peu d'aventuriers empruntent cette sente pour se rendre dans le cirque d'Argoneskan.",
         "categorie": "cartographie",
         "created": "20150604083913839",
         "faction_id": "15",
+        "guarded": "false",
         "id": "85",
         "itineraire": "",
         "map_id": "1",
@@ -7084,14 +7085,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Sentier du cirque d'Argoneskan",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Ce sentier permet de se rendre au Monastère de Sainte Velathys, qui se tient à l'écart de la Voie des pèlerins, sur les flancs du pic Venteux.",
         "categorie": "cartographie",
         "created": "20150402154723350",
         "faction_id": "15",
+        "guarded": "false",
         "id": "86",
         "map_id": "1",
         "markerend_id": "97",
@@ -7101,14 +7102,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Sentier du Monastère du pic Venteux",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "Ce chemin permet de joindre Nectan à Deh'ad. Moins utilisé que la célèbre Voie sainte, il suit la lisière entre la forêt du Dorchwald et les contreforts des Mòr Roimh.",
         "categorie": "cartographie",
         "created": "20150715201921545",
         "faction_id": "15",
+        "guarded": "false",
         "id": "87",
         "itineraire": "Route du Dorchwald",
         "map_id": "1",
@@ -7119,14 +7120,14 @@
         "status": "done",
         "tags": "routes",
         "title": "Route du Dorchwald (du carrefour des Pierres Brisées à Deh'ad)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150720203141261",
         "faction_id": "11",
+        "guarded": "false",
         "id": "88",
         "itineraire": "Route de l'Océan",
         "map_id": "1",
@@ -7137,14 +7138,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Bac de l'embouchure du Kreizhdour",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150720201743957",
         "faction_id": "",
+        "guarded": "false",
         "id": "89",
         "itineraire": "Route des Hilderins",
         "map_id": "1",
@@ -7155,14 +7156,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Didean à Louarn",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150330133724682",
         "faction_id": "9",
+        "guarded": "false",
         "id": "9",
         "map_id": "1",
         "markerend_id": "18",
@@ -7172,14 +7173,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Gwidre (du pont sur le Donir de Kember au château des Mac Emmanon)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331122722234",
         "faction_id": "",
+        "guarded": "false",
         "id": "90",
         "itineraire": "Route des Hilderins",
         "map_id": "1",
@@ -7190,14 +7191,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de la Citadelle de Dèas à Didean",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331121829633",
         "faction_id": "",
+        "guarded": "false",
         "id": "91",
         "itineraire": "Route des Hilderins",
         "map_id": "1",
@@ -7208,14 +7209,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Llewellen à Tulg Naomh",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331122120529",
         "faction_id": "",
+        "guarded": "false",
         "id": "92",
         "itineraire": "Route des Hilderins",
         "map_id": "1",
@@ -7226,14 +7227,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Louarn à Llewellen",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331115202231",
         "faction_id": "1",
+        "guarded": "false",
         "id": "93",
         "itineraire": "Chemin de Norgord",
         "map_id": "1",
@@ -7244,14 +7245,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Norgord (des carrières de Norgord à l'abbaye de Corvus)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150721221202405",
         "faction_id": "2",
+        "guarded": "false",
         "id": "94",
         "itineraire": "",
         "map_id": "1",
@@ -7262,14 +7263,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Promesse",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150721215408490",
         "faction_id": "15",
+        "guarded": "false",
         "id": "95",
         "itineraire": "Chemin de Ruel",
         "map_id": "1",
@@ -7280,14 +7281,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Ruel (d'Ard-Monach au carrefour de Ruel)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150721215339800",
         "faction_id": "15",
+        "guarded": "false",
         "id": "96",
         "itineraire": "Chemin de Ruel",
         "map_id": "1",
@@ -7298,14 +7299,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Ruel (du carrefour de Jarnel à Kaer Daegis)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150721215354996",
         "faction_id": "15",
+        "guarded": "false",
         "id": "97",
         "itineraire": "Chemin de Ruel",
         "map_id": "1",
@@ -7316,14 +7317,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Ruel (du carrefour de Ruel au carrefour de Jarnel)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150331120726300",
         "faction_id": "4",
+        "guarded": "false",
         "id": "98",
         "itineraire": "Route de l'Océan",
         "map_id": "1",
@@ -7334,14 +7335,14 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Océan (d'Aimliù à Diinthër)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     },
     {
         "text": "",
         "categorie": "cartographie",
         "created": "20150720203924438",
         "faction_id": "11",
+        "guarded": "false",
         "id": "99",
         "itineraire": "Route de l'Océan",
         "map_id": "1",
@@ -7352,7 +7353,6 @@
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Océan (de Diinthër à Ard-Amrach)",
-        "zoneparent_id": "",
-        "guarded": "false"
+        "zoneparent_id": ""
     }
 ]

--- a/data/tiddlers.json
+++ b/data/tiddlers.json
@@ -525,8 +525,8 @@
         "faction_id": "4",
         "id": "11",
         "map_id": "1",
-        "modified": "20150706210730691",
-        "status": "à placer",
+        "modified": "20150924111441558",
+        "status": "done",
         "tags": "zones",
         "title": "Falaises sans retour",
         "zoneparent_id": "id_Continent",
@@ -539,8 +539,8 @@
         "faction_id": "12",
         "id": "12",
         "map_id": "1",
-        "modified": "20150706211112359",
-        "status": "à placer",
+        "modified": "20150922110150295",
+        "status": "done",
         "tags": "zones",
         "title": "Collines Tristes",
         "zoneparent_id": "25",
@@ -553,8 +553,8 @@
         "faction_id": "4",
         "id": "13",
         "map_id": "1",
-        "modified": "20150708105744594",
-        "status": "à placer",
+        "modified": "20150922102715204",
+        "status": "done",
         "tags": "zones",
         "title": "Bois de Calhtair",
         "zoneparent_id": "38",
@@ -581,8 +581,8 @@
         "faction_id": "4",
         "id": "15",
         "map_id": "1",
-        "modified": "20150711113607500",
-        "status": "à placer",
+        "modified": "20150924105307323",
+        "status": "done",
         "tags": "zones",
         "title": "Collines Jaunes",
         "zoneparent_id": "25",
@@ -655,7 +655,7 @@
         "status": "done",
         "tags": "zones",
         "title": "Cité de Kember",
-        "zoneparent_id": "id_Royaume de Reizh",
+        "zoneparent_id": "57",
         "zonetype_id": "5"
     },
     {
@@ -673,18 +673,18 @@
         "zonetype_id": "14"
     },
     {
-        "created": "20150323161233390",
         "text": "Le royaume de Taol-Kaer occupe toute la partie méridionale de la péninsule de Tri-Kazel, séparé du Gwidre par le fleuve Kreizhdour et du Reizh par le fleuve Tealderoth. Le roi actuel est Erald Mac Anweald, qui gouverne les huit duchés depuis la capitale Osta-Baille, les Terres de Dèas restant quant à elles peu soumises à l'autorité royale. Le royaume, peuplé d'un peu plus d'un million d'habitants dispersés dans quelques grandes villes et beaucoup de villages, est resté fidèle aux anciennes traditions demorthèn, tournées vers la nature.",
         "categorie": "cartographie",
+        "created": "20150323161233390",
         "faction_id": "9",
         "id": "25",
         "map_id": "1",
-        "modified": "20150921193727651",
+        "modified": "20150922164245753",
+        "status": "done",
         "tags": "zones",
         "title": "Royaume de Taol-Kaer",
         "zoneparent_id": "id_Péninsule de Tri-Kazel",
-        "zonetype_id": "2",
-        "status": "à intégrer"
+        "zonetype_id": "2"
     },
     {
         "text": "Dans le comté de Frendian, la dureté des montagnes et la noirceur des forêts laissent place à un val paisible aux couleurs chaudes et joyeuses. Ici les palissades sont rares et les habitants ne semblent pas craindre les feondas tapis dans l'ombre. Ce serait l'effet du cercle de pierre entretenu par le demorthèn local, récemment décédé. La comtesse Adnae Mac Marzin n'a que peu de relations avec la couronne talkéride.",
@@ -693,8 +693,8 @@
         "faction_id": "9",
         "id": "26",
         "map_id": "1",
-        "modified": "20150706211100807",
-        "status": "à placer",
+        "modified": "20150922104245819",
+        "status": "done",
         "tags": "zones",
         "title": "Comté de Frendian",
         "zoneparent_id": "id_Duché d'Osta-Baille",
@@ -707,8 +707,8 @@
         "faction_id": "14",
         "id": "27",
         "map_id": "1",
-        "modified": "20150706210833651",
-        "status": "à placer",
+        "modified": "20150922104920576",
+        "status": "done",
         "tags": "zones",
         "title": "Domaine des Mac Govrian",
         "zoneparent_id": "42",
@@ -721,8 +721,8 @@
         "faction_id": "9",
         "id": "28",
         "map_id": "1",
-        "modified": "20150706210833131",
-        "status": "à placer",
+        "modified": "20150922104646649",
+        "status": "done",
         "tags": "zones",
         "title": "Domaine des Mac Lyr",
         "zoneparent_id": "45",
@@ -735,11 +735,11 @@
         "faction_id": "4",
         "id": "29",
         "map_id": "1",
-        "modified": "20150706210743600",
-        "status": "à placer",
+        "modified": "20150925104556628",
+        "status": "done",
         "tags": "zones",
         "title": "Falaises des Amertumes",
-        "zoneparent_id": "id_Royaume de Reizh",
+        "zoneparent_id": "57",
         "zonetype_id": "11"
     },
     {
@@ -749,11 +749,11 @@
         "faction_id": "9",
         "id": "3",
         "map_id": "1",
-        "modified": "20150706211038526",
-        "status": "à placer",
+        "modified": "20150922105214453",
+        "status": "done",
         "tags": "zones",
         "title": "Domaine des Mac Emmanon",
-        "zoneparent_id": "id_Royaume de Reizh",
+        "zoneparent_id": "57",
         "zonetype_id": "4"
     },
     {
@@ -767,7 +767,7 @@
         "status": "done",
         "tags": "zones",
         "title": "Forêt des Murmures",
-        "zoneparent_id": "id_Gwidre",
+        "zoneparent_id": "56",
         "zonetype_id": "8"
     },
     {
@@ -805,8 +805,8 @@
         "faction_id": "4",
         "id": "33",
         "map_id": "1",
-        "modified": "20150711113609307",
-        "status": "à placer",
+        "modified": "20150924110554651",
+        "status": "done",
         "tags": "zones",
         "title": "Grandes Plages",
         "zoneparent_id": "25",
@@ -819,8 +819,8 @@
         "faction_id": "4",
         "id": "34",
         "map_id": "1",
-        "modified": "20150706210553602",
-        "status": "à placer",
+        "modified": "20150925103229763",
+        "status": "done",
         "tags": "zones",
         "title": "Hautes landes de Tùrsal",
         "zoneparent_id": "25",
@@ -833,8 +833,8 @@
         "faction_id": "4",
         "id": "35",
         "map_id": "1",
-        "modified": "20150711113609932",
-        "status": "à placer",
+        "modified": "20150922104024180",
+        "status": "done",
         "tags": "zones",
         "title": "Marécages gris",
         "zoneparent_id": "25",
@@ -861,8 +861,8 @@
         "faction_id": "4",
         "id": "37",
         "map_id": "1",
-        "modified": "20150711113610121",
-        "status": "à placer",
+        "modified": "20150925105419448",
+        "status": "done",
         "tags": "zones",
         "title": "Monts Asgeamar",
         "zoneparent_id": "id_Péninsule de Tri-Kazel",
@@ -931,8 +931,8 @@
         "faction_id": "4",
         "id": "41",
         "map_id": "1",
-        "modified": "20150706205842252",
-        "status": "à placer",
+        "modified": "20150922105848488",
+        "status": "done",
         "tags": "zones",
         "title": "Plateau de Norgord",
         "zoneparent_id": "39",
@@ -945,8 +945,8 @@
         "faction_id": "4",
         "id": "42",
         "map_id": "1",
-        "modified": "20150708114129234",
-        "status": "à placer",
+        "modified": "20150924113306754",
+        "status": "done",
         "tags": "zones",
         "title": "Val de Dearg",
         "zoneparent_id": "id_Duché de Tulg",
@@ -959,8 +959,8 @@
         "faction_id": "3",
         "id": "43",
         "map_id": "1",
-        "modified": "20150706204437389",
-        "status": "à placer",
+        "modified": "20150925102833510",
+        "status": "done",
         "tags": "zones",
         "title": "Val de Jarnel",
         "zoneparent_id": "24",
@@ -973,8 +973,8 @@
         "faction_id": "4",
         "id": "44",
         "map_id": "1",
-        "modified": "20150706204435271",
-        "status": "à placer",
+        "modified": "20150924113219905",
+        "status": "done",
         "tags": "zones",
         "title": "Val de Loch Varn",
         "zoneparent_id": "id_Duché de Tulg",
@@ -987,8 +987,8 @@
         "faction_id": "4",
         "id": "45",
         "map_id": "1",
-        "modified": "20150706204432416",
-        "status": "à placer",
+        "modified": "20150924113219370",
+        "status": "done",
         "tags": "zones",
         "title": "Val de Melwan",
         "zoneparent_id": "id_Duché de Tulg",
@@ -1019,7 +1019,7 @@
         "status": "done",
         "tags": "zones",
         "title": "Forêt de Taelwald",
-        "zoneparent_id": "id_Royaume de Reizh",
+        "zoneparent_id": "57",
         "zonetype_id": "8"
     },
     {
@@ -1029,11 +1029,11 @@
         "faction_id": "4",
         "id": "5",
         "map_id": "1",
-        "modified": "20150711113608065",
-        "status": "à placer",
+        "modified": "20150922103349185",
+        "status": "done",
         "tags": "zones",
         "title": "Dorchwald",
-        "zoneparent_id": "id_Gwidre",
+        "zoneparent_id": "56",
         "zonetype_id": "8"
     },
     {
@@ -1043,11 +1043,11 @@
         "faction_id": "1",
         "id": "52",
         "map_id": "1",
-        "modified": "20150711113611042",
-        "status": "à placer",
+        "modified": "20150922105633689",
+        "status": "done",
         "tags": "zones",
         "title": "Région d'Abondance",
-        "zoneparent_id": "id_Gwidre",
+        "zoneparent_id": "56",
         "zonetype_id": "17"
     },
     {
@@ -1057,8 +1057,8 @@
         "faction_id": "4",
         "id": "54",
         "map_id": "1",
-        "modified": "20150711113607135",
-        "status": "à placer",
+        "modified": "20150924113023827",
+        "status": "done",
         "tags": "zones",
         "title": "Cirque d'Argoneskan",
         "zoneparent_id": "39",
@@ -1071,12 +1071,26 @@
         "faction_id": "4",
         "id": "55",
         "map_id": "1",
-        "modified": "20150711113608249",
-        "status": "à placer",
+        "modified": "20150925103817840",
+        "status": "done",
         "tags": "zones",
         "title": "Failles Hurlantes",
         "zoneparent_id": "39",
         "zonetype_id": "11"
+    },
+    {
+        "text": "Le royaume de Gwidre se situe au nord ouest de la péninsule de Tri-Kazel, séparé de Taol-Kaer par le fleuve Kreizhdour. Le roi actuel, Dalenverch IV, gouverne depuis la capitale Ard-Amrach un peuple d'environ six cent mille habitants. Il est aidé dans sa tâche par le Hiérophante Anthénor, chef suprême du Temple. Cette religion continentale du Dieu Unique est en effet devenue la foi officielle du royaume, et les demorthèn et les anciennes traditions y sont pourchassés.",
+        "categorie": "cartographie",
+        "created": "20150306122658572",
+        "faction_id": "9",
+        "id": "56",
+        "map_id": "1",
+        "modified": "20150922164251369",
+        "status": "à placer",
+        "tags": "zones",
+        "title": "Royaume de Gwidre",
+        "zoneparent_id": "id_Péninsule de Tri-Kazel",
+        "zonetype_id": "2"
     },
     {
         "text": "Ce large golfe forme l'extrémité nord de la Mer des Linceuls, bordé par la côte du Reizh.",
@@ -1093,14 +1107,28 @@
         "zonetype_id": "13"
     },
     {
+        "text": "Le royaume de Reizh se situe à l'est de la péninsule de Tri-Kazel, séparé de Taol-Kaer par le fleuve Tealderoth et du Continent par les immenses Monts Asgeamar. Bronchaerd, le roi actuel, gouverne depuis la capitale Baldh-Ruoch un peuple d'environ cinq cent mille habitants. Le royaume a accueilli favorablement les théories magientistes et la modernité qu'elle apportent, mais sa situation politique est délicate : si la principauté de Farl, au nord, est loyale au trône, ce n'est pas le cas des seigneurs féodaux du Croissant d’Émeraude, soutenus par les demorthèn.",
+        "categorie": "cartographie",
+        "created": "20150323160942160",
+        "faction_id": "9",
+        "id": "57",
+        "map_id": "1",
+        "modified": "20150922164252055",
+        "status": "à placer",
+        "tags": "zones",
+        "title": "Royaume de Reizh",
+        "zoneparent_id": "id_Péninsule de Tri-Kazel",
+        "zonetype_id": "2"
+    },
+    {
         "text": "Ces marais moroses représentent une des rares sources de sel de toute la péninsule, et font toute la richesse du duché de Salann Tir. Les nombreux renégats qui s'y cachent, dans des ruines ou les villages les plus pauvres, se sont organisés en une bande, surnommée les \"Roseaux de fer\".",
         "categorie": "cartographie",
         "created": "20150331111232408",
         "faction_id": "12",
         "id": "58",
         "map_id": "1",
-        "modified": "20150711113609729",
-        "status": "à placer",
+        "modified": "20150922103736766",
+        "status": "done",
         "tags": "zones",
         "title": "Marais du Ponant",
         "zoneparent_id": "25",
@@ -1113,11 +1141,11 @@
         "faction_id": "4",
         "id": "6",
         "map_id": "1",
-        "modified": "20150706211324906",
-        "status": "à placer",
+        "modified": "20150922102911444",
+        "status": "done",
         "tags": "zones",
         "title": "Boischandelles",
-        "zoneparent_id": "id_Royaume de Reizh",
+        "zoneparent_id": "57",
         "zonetype_id": "8"
     },
     {
@@ -1131,7 +1159,7 @@
         "status": "à placer",
         "tags": "zones",
         "title": "Croissant d'Émeraude",
-        "zoneparent_id": "id_Royaume de Reizh",
+        "zoneparent_id": "57",
         "zonetype_id": "17"
     },
     {
@@ -1141,8 +1169,8 @@
         "faction_id": "5",
         "id": "8",
         "map_id": "1",
-        "modified": "20150711113610653",
-        "status": "à placer",
+        "modified": "20150924110223373",
+        "status": "done",
         "tags": "zones",
         "title": "Mur des Lances",
         "zoneparent_id": "39",
@@ -1155,40 +1183,12 @@
         "faction_id": "4",
         "id": "9",
         "map_id": "1",
-        "modified": "20150711113608977",
-        "status": "à placer",
+        "modified": "20150924112828340",
+        "status": "done",
         "tags": "zones",
         "title": "Gouffre Carmin",
         "zoneparent_id": "39",
         "zonetype_id": "11"
-    },
-    {
-        "created": "20150306122658572",
-        "text": "Le royaume de Gwidre se situe au nord ouest de la péninsule de Tri-Kazel, séparé de Taol-Kaer par le fleuve Kreizhdour. Le roi actuel, Dalenverch IV, gouverne depuis la capitale Ard-Amrach un peuple d'environ six cent mille habitants. Il est aidé dans sa tâche par le Hiérophante Anthénor, chef suprême du Temple. Cette religion continentale du Dieu Unique est en effet devenue la foi officielle du royaume, et les demorthèn et les anciennes traditions y sont pourchassés.",
-        "categorie": "cartographie",
-        "faction_id": "9",
-        "id": "56",
-        "map_id": "1",
-        "modified": "20150921195154138",
-        "status": "à intégrer",
-        "tags": "zones",
-        "title": "Royaume de Gwidre",
-        "zoneparent_id": "id_Péninsule de Tri-Kazel",
-        "zonetype_id": "2"
-    },
-    {
-        "created": "20150323160942160",
-        "text": "Le royaume de Reizh se situe à l'est de la péninsule de Tri-Kazel, séparé de Taol-Kaer par le fleuve Tealderoth et du Continent par les immenses Monts Asgeamar. Bronchaerd, le roi actuel, gouverne depuis la capitale Baldh-Ruoch un peuple d'environ cinq cent mille habitants. Le royaume a accueilli favorablement les théories magientistes et la modernité qu'elle apportent, mais sa situation politique est délicate : si la principauté de Farl, au nord, est loyale au trône, ce n'est pas le cas des seigneurs féodaux du Croissant d’Émeraude, soutenus par les demorthèn.",
-        "categorie": "cartographie",
-        "faction_id": "9",
-        "id": "57",
-        "map_id": "1",
-        "modified": "20150921193822091",
-        "status": "à intégrer",
-        "tags": "zones",
-        "title": "Royaume de Reizh",
-        "zoneparent_id": "id_Péninsule de Tri-Kazel",
-        "zonetype_id": "2"
     },
     {
         "text": "Ce village côtier est peu prisé des navigateurs, d'une part à cause des hauts-fonds et écueils qui provoquent de fréquents naufrages, et d'autre part parce que ses habitants se comportent étrangement, aussi bien à l'égard des étrangers que de la mer.",
@@ -1202,7 +1202,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Aimliù",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "Cette petite forteresse, située à la pointe sud de l'île du Calvaire, est équipée d'un phare et d'un petit port. Sa garnison est relevée deux fois l'an.",
@@ -1335,7 +1335,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Carrefour du cirque d'Argoneskan sur la Route de la mer",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Ce château, accroché au flanc du pic des Corbeaux, gardait à l'origine des mines d'argent, épuisées depuis des siècles. Longtemps abandonné, il n'a été restauré qu'au siècle dernier par des Continentaux, les Nevermore, qui ont repris l'ancien blason au corbeau perché. Cette étrange famille tient à rester à l'écart du monde, même si des projets d'infrastructure routière, à défaut des tensions du royaume, risquent de les forcer à s'y impliquer.",
@@ -1350,7 +1350,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Château des Nevermore",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Enjambant le fleuve Tealderoth, ce pont entre les royaumes de Taol-Kaer et Reizh est le symbole de leur alliance durant la guerre du Temple. Cependant, l'existence d'un pont ici remonterait bien plus loin, aux temps de la Fondation.",
@@ -1378,7 +1378,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Kell",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Ce sommet doit son nom aux nombreux corbeaux qui y nichent, et qui ornent également le blason du vieux château installé sur un flanc du pic. Celui-ci gardait à l'origine des mines d'argent creusées dans la montagne, épuisées depuis longtemps. Il a récemment été restauré par une famille continentale, les Nevermore.",
@@ -1420,7 +1420,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Bac à l'embouchure du Kreizhdour, côté gwidrite",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "",
@@ -1490,7 +1490,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Carrefour de Promesse sur la Route royale",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "",
@@ -1505,7 +1505,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Carrefour des Pierres Brisées sur la route du Dorchwald",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "Le \"belvédère de l'est\" est le liagcal oriental, probablement le plus magnifique et le plus important des quatre sanctuaires demorthèn que compte la péninsule de Tri-Kazel. Malheureusement l'influence du Tsioghair, le conseil annuel, est en déclin, au profit d'intrigues politiques avec les diverses puissances en Reizh.",
@@ -1519,7 +1519,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Fairean Ear",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Ces carrières sont le seul endroit de tout Tri-Kazel où l'albanite est extraite. La puissante guilde de Báncloch dirigée par la famille Mac Mannàn, propriétaire des lieux, y exerce son pouvoir par la force, au mépris des ouvriers dont les conditions de travail sont déplorables.",
@@ -1534,7 +1534,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Carrières d'Arden",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "Ces carrières sont célèbres pour leur marbre blanc de grande qualité, prisé jusqu'en Taol-Kaer mais surtout convoité par le Temple. Ce dernier a perdu depuis peu une partie du contrôle des carrières, au profit de la couronne gwidrite.",
@@ -1590,7 +1590,7 @@
         "status": "à revoir",
         "tags": "marqueurs",
         "title": "Citadelle de Kermordhran",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "",
@@ -1678,7 +1678,7 @@
         "status": "à revoir",
         "tags": "marqueurs",
         "title": "Kalvernach",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Il parait qu'un loup géant couvert de barbelures habite ces lieux. C'est pour cette raison qu'on le surnomme aussi la \"brèche du loup\".",
@@ -1706,7 +1706,7 @@
         "status": "à revoir",
         "tags": "marqueurs",
         "title": "Gleb",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Ce bourg est réputée dans toute la région pour ses artisans du bois. Un constructeur vante l'efficacité de sa machine magientiste, mais les habitants restent sceptiques.",
@@ -1792,7 +1792,7 @@
         "status": "à revoir",
         "tags": "marqueurs",
         "title": "Pont de Brian'ch",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Cet ouvrage architectural n'apparaîtrait qu'en certaines circonstances, qui restent indéterminées. Il est difficile de dire si ce pont existe vraiment ou si c'est de l'ordre de la légende.",
@@ -1821,7 +1821,7 @@
         "status": "à revoir",
         "tags": "marqueurs",
         "title": "Port de Farl",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Ici, au sud du royaume de Reizh, se croisent les routes venant du Baldh-Ruoch, de Kalvernach, du Pont de l'Alliance et de Fairean Ear.",
@@ -1835,7 +1835,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Carrefour de l'entrée du Reizh",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "",
@@ -1878,7 +1878,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Carrefour de Corvus sur la route du Dorchwald",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "",
@@ -1908,7 +1908,7 @@
         "status": "à revoir",
         "tags": "marqueurs",
         "title": "Kroazen",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "",
@@ -2309,7 +2309,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Clos-des-Cendres",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Depuis que le missionnaire saint Jamian aurait accosté ici en 713, cet ancien village de pêcheurs a été renommé en cet honneur Fionnfuar ou \" froid sacré \". Il est devenu un imposant lieu de pèlerinage pour les croyants en l'Unique, qui empruntent la Voie sainte pour venir se recueillir sur le magnifique tombeau du saint. Le recteur de l'église de Fionnfuar, actuellement le prêtre reizhite Andrev, est traditionnellement aussi le dirigeant de l'ordre des prêtres.",
@@ -2323,7 +2323,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Fionnfuar",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "Le \"joyau du Nord\" est l'une des plus importantes et plus riches cités du nord de Reizh, tournée principalement vers les industries du textile et du papier. C'est aussi une ville mixte qui, sous l'impulsion du Prince Gweltas Mac Lenneïden et de ses prédécesseurs, accueille en son sein des magientistes, des demorthèn et des représentants du Temple. Ces trois idéologies peuvent ici s'épanouir et faire bénéficier la cité du meilleur de chacune, ce qui fait dire à ses habitants qu'elle est un modèle pour les Trois Royaumes.",
@@ -2337,7 +2337,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Farl",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Située à un point stratégique, non loin de la citadelle éponyme réputée inviolable, cette ville de garnison s'est développée et sécurisée depuis que le roi de Reizh y a récemment nommé un gouverneur pour diriger la cité et la région environnante.",
@@ -2351,7 +2351,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Kermordhran",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "",
@@ -2365,7 +2365,7 @@
         "status": "à revoir",
         "tags": "marqueurs",
         "title": "Afalinn",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Cette brèche est le seul passage permettant d'accéder à cette formation rocheuse naturellement circulaire, qui doit son nom à son découvreur Pelfreinth Argoneskan.",
@@ -2393,7 +2393,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Gouvran",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "Cette ville, première étape d'importance sur la Voie sainte, est réputée pour ses artisans, principalement menuisiers et teinturiers.",
@@ -2407,7 +2407,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Nectan",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "Ce village niché dans les collines a une activité commerçante notable.",
@@ -2421,7 +2421,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Deh'ad",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "Ce village s’étend dans une petite vallée de la forêt du Dorchwald.",
@@ -2435,7 +2435,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Lenbach",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "De nombreux demorthèn se rejoignaient à l'ancien liagcal du nord, avant que le Temple ne décide de le purifier violemment et ne détruise le cercle de pierres. Malgré une tentative d'y installer une église soustrainienne, ce site est aujourd'hui laissé à l'abandon et souvent envahi de brouillard. En effet, les prêtres qui y ont été affectés ont disparu les uns après les autres.",
@@ -2449,7 +2449,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Pierres Brisées",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "L'abbaye de Corvus est un établissement fortifié, habité par une congrégation de moines-guerriers, les frères corvusiens. Ils parcourent les routes et surveillent les frontières de Gwidre, avec l'aide des criminels condamnés qu'ils encadrent, et qui parfois finissent par rejoindre leur ordre.",
@@ -2463,7 +2463,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Abbaye de Corvus",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "Ancien fort dévolu à la défense de la frontière avec Gwidre, bâti sur un promontoire balayé par les vents froids, ce manoir n'est aujourd'hui guère plus qu'une ruine à peine habitable, confiée au cadet de la famille Mac Emmanon.",
@@ -2492,7 +2492,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Gué Sanglant",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "",
@@ -2506,7 +2506,7 @@
         "status": "à revoir",
         "tags": "marqueurs",
         "title": "Demeure des Mac Baellec",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Crail est un bourg situé dans des vallons forestiers traversés par la rivière Seleane. Ses artisans du bois, constitués en guilde, sont reconnus pour leur savoir-faire ; ils produisent des meubles et des bibelots aux tons riches, mais aussi des armes de qualité. Aussi y a-t-il souvent des marchands de passage, qu'ils soient reizhites ou viennent de l'autre côté de la frontière.",
@@ -2520,7 +2520,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Crail",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Ce petit village frontalier est situé à proximité d'une garnison de chevaliers hilderins, dont les incursions sont sources de tension pour les habitants, d'autant plus que des vols et faits étranges sont souvent rapportés.",
@@ -2534,7 +2534,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Gline",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Ce bourg est reconnu pour la qualité de sa laine, et l'efficacité de ses tisserands. Ceux-ci s'y sont constitués en guilde, plus puissante que le seigneur local. Jusqu'à présent, ils ont toujours refusé d'utiliser des métiers à tisser magientistes.",
@@ -2548,7 +2548,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Leacach",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Promesse est un village nouveau dont la centaine d'occupants, dirigée par trois primus, est dédiée aux exploitations magientistes : l'extration du Flux végétal dans la forêt de Boischandelles, celle du Flux fossile des mines d'une vallée voisine... et la protection contre les \"insoumis\" des clans indépendantistes, qui mènent une véritable guérilla contre les magientistes.",
@@ -2562,7 +2562,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Promesse",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Ces mines étaient exploitées localement pour le minerai de fer jusqu'à ce que du Flux fossile y soit découvert, ce qui a occasionné leur rachat par les magientistes de Promesse et exacerbé les tensions avec les clans traditionnels de la région.",
@@ -2576,7 +2576,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Mines de Promesse",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Ce petit village isolé est le point de passage obligé pour ceux qui souhaitent rejoindre le Continent en traversant les Monts Asgeamar.",
@@ -2590,7 +2590,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Iolairnead",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Ce col est le commencement d'un long périple à travers les Monts Asgeamar pour quitter la péninsule et rejoindre le Simahir, sur le Continent.",
@@ -2604,7 +2604,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Col de Gaos-Bodhar",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Ce village côtier est nommé fort à propos le \"port de l'Est\", puisqu'il est le port le plus oriental de la péninsule, et un des principaux sur la mer des Linceuls. Situé à l'embouchure du Donir, il est aussi au départ des routes fluviales qui remontent jusqu'à la capitale Baldh-Ruoch, ce qui en fait une plaque tournante du commerce reizhite, et notamment du Croissant d’Émeraude. Devenu trop petit, une grande partie du trafic maritime a été déplacé dans un nouveau port, Nua Caladh.",
@@ -2618,7 +2618,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Ear Caladh",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "La capitale du royaume de Reizh. Un lieu majestueux dont la beauté rivalise avec la modernité que l'on trouve à chaque coin de rue.",
@@ -2632,7 +2632,7 @@
         "status": "à revoir",
         "tags": "marqueurs",
         "title": "Baldh-Ruoch",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "Le château de Laräch était la demeure des comtes des Marches, les Mac Farquam, vieille lignée garante de la frontière avec Gwidre. En effet, le château domine un pont sur le fleuve Kreizdhour. Toutefois, leur trahison pendant la guerre du Temple signa leur déchéance, complétée par l'incendie du château. Depuis lors, ses ruines sont considérées comme maudites.",
@@ -2674,7 +2674,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Gorm Caladh",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "La Cathédrale Saint Albérich est le lieu de pèlerinage privilégié des chevaliers lames, de leur acceptation à la fin de leur carrière, quand ils viennent y achever leur service dans la garde honorifique.",
@@ -2688,7 +2688,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Cathédrale Saint Albérich",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "La célèbre \"cité-escalier\", capitale du duché de Tulg, s'élève des taudis des bas fonds aux riches quartiers du sommet. Son phare qui illumine le port est bien connu des navigateurs. La ville prospère grâce au commerce, aussi bien terrestre que maritime. Couplé au sentiment de délaissement de la part de la couronne talkéride lors de la guerre du Temple, cela attise les volontés d'indépendance de la ville, bien que la duchesse du Tulg, Cortessa Mac Lichorl, soit loyale au trône.",
@@ -2842,7 +2842,7 @@
         "status": "à revoir",
         "tags": "marqueurs",
         "title": "Mambrun",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "",
@@ -2856,7 +2856,7 @@
         "status": "à revoir",
         "tags": "marqueurs",
         "title": "Château des Roharën",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "La capitale du duché de Dùlan, qui s'est établie autour d'une citadelle, serait la cité la plus haute en altitude de Tri-Kazel. Ses prisons sont pleines, du fait de la justice implacable du duc Làn Mac Torrach, quand les malandrins pris sur le fait ne sont pas pendus haut et court sans autre forme de procès.",
@@ -3015,7 +3015,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Rhingal",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "Cette ville dans l'estuaire de la Klaedhin est entièrement construite sur pilotis pour gagner sur les marécages gris. Jusqu'en 758, c'était l'ancienne capitale de Taol-Kaer. Personne n'est sans savoir que depuis que leur cité n'est plus le centre politique du royaume, le peuple aussi bien que la noblesse de Tuaille vouent une haine forte à Osta-Baille, et les rumeurs de complots vont bon train.",
@@ -3057,7 +3057,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Expiation",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "Seòl signifie \"voile\" dans l'ancienne langue. Plus que pour ses bateaux, la capitale du duché de Seòl est surtout connue pour ses chars à voiles permettant de traverser rapidement les Grandes Plages, et dont les équipages rivalisent avec la confrérie des marins. Les guildes marchandes y sont puissantes, bénéficiant de largesses du duc Angus Mac Iseanor.",
@@ -3300,7 +3300,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Carrefour du pic Ordachaï sur la Voie des pèlerins",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "",
@@ -3315,7 +3315,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Carrefour du pic Venteux sur la Voie des pèlerins",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "L'architecture de cette bâtisse, perchée au sommet d'un pic, surprend par ses ornementations arachnéennes et ses flèches blanches qui s'élancent à l'assaut du ciel. Il n'existe pas de chemin pour s'y rendre, et l'on dit que ce ne sont pas les hommes qui l'ont construite.",
@@ -3343,7 +3343,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Ard-Amrach",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "Ce col est le seul passage du côté talkéride qui permette de se rendre à la forteresse d'Aelwyd Saogh. Depuis que le roi Maelvon y a disparu en 360 avec ses chevaliers, on le dit hanté, et de nombreux chasseurs de trésor y ont cherché la couronne de Taol-Kaer.",
@@ -3458,7 +3458,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Monastère du pic Venteux",
-        "zoneparent_id": "id_Gwidre"
+        "zoneparent_id": "56"
     },
     {
         "text": "Ce bourg, dont le nom signifie le \"nouveau port\", est le pendant d'Ear Caladh. La complexité de sa récente construction, qui a nécessité la création d'une anse artificielle, explique que les taxes portuaires y soient si élevées. Ses habitants sont majoritairement des employés portuaires.",
@@ -3472,7 +3472,7 @@
         "status": "done",
         "tags": "marqueurs",
         "title": "Nua Caladh",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57"
     },
     {
         "text": "L'un des deux phares fortifiés de l'île du Calvaire équipé d'un petit port, situé sur l'extrémité ouest des côtes. Sa garnison est relevée deux fois l'an.",
@@ -3499,12 +3499,13 @@
         "map_id": "1",
         "markerend_id": "21",
         "markerstart_id": "19",
-        "modified": "20150720202758921",
+        "modified": "20151005183430522",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route des Cendres",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3516,12 +3517,13 @@
         "map_id": "1",
         "markerend_id": "46",
         "markerstart_id": "45",
-        "modified": "20150723194749349",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Océan (de Gorm Caladh à Saint Albérich)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3533,12 +3535,13 @@
         "map_id": "1",
         "markerend_id": "10",
         "markerstart_id": "46",
-        "modified": "20150723194759822",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Océan (de Saint Albérich à Aimliù)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3550,12 +3553,13 @@
         "map_id": "1",
         "markerend_id": "114",
         "markerstart_id": "47",
-        "modified": "20150723194923022",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Océan (de Tulg Naomh au bac)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3567,12 +3571,13 @@
         "map_id": "1",
         "markerend_id": "45",
         "markerstart_id": "113",
-        "modified": "20150723194942672",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Océan (du bac à Gorm Caladh)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3584,12 +3589,13 @@
         "map_id": "1",
         "markerend_id": "141",
         "markerstart_id": "135",
-        "modified": "20150723200150481",
+        "modified": "20151005183430522",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route des Hilderins (d'Ostreach à Tilliarch)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3601,12 +3607,13 @@
         "map_id": "1",
         "markerend_id": "135",
         "markerstart_id": "79",
-        "modified": "20150723195905982",
+        "modified": "20151005183430522",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route des Hilderins (de Merieren à Ostreach)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3618,12 +3625,13 @@
         "map_id": "1",
         "markerend_id": "123",
         "markerstart_id": "141",
-        "modified": "20150723200608602",
+        "modified": "20151005183430522",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route des Hilderins (de Tilliarch à la Citadelle de Dèas)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3635,12 +3643,13 @@
         "map_id": "1",
         "markerend_id": "139",
         "markerstart_id": "21",
-        "modified": "20150723200434044",
+        "modified": "20151005183430523",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du port de Farl",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3651,12 +3660,13 @@
         "map_id": "1",
         "markerend_id": "84",
         "markerstart_id": "135",
-        "modified": "20150724200928005",
+        "modified": "20151005183430507",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin d'Ostreach à Cardach",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3667,12 +3677,13 @@
         "map_id": "1",
         "markerend_id": "170",
         "markerstart_id": "30",
-        "modified": "20150906140951210",
+        "modified": "20151005183430514",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin gwidrite de Corvus à Kermordhran",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3684,12 +3695,13 @@
         "map_id": "1",
         "markerend_id": "33",
         "markerstart_id": "13",
-        "modified": "20150906160730803",
+        "modified": "20151005183430524",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route royale (de Kalvernach à la demeure des Mac Baellec)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3701,12 +3713,13 @@
         "map_id": "1",
         "markerend_id": "121",
         "markerstart_id": "144",
-        "modified": "20150724201425692",
+        "modified": "20151005183430510",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Norgord (de Kroazen aux carrières de Norgord)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Le route qui mène aux carrières de marbre blanc du plateau de Norgord a été financée par le clergé du Temple, qui l'apprécie pour la construction de ses églises.",
@@ -3718,12 +3731,13 @@
         "map_id": "1",
         "markerend_id": "144",
         "markerstart_id": "87",
-        "modified": "20150823084939481",
+        "modified": "20151005183430510",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Norgord (du carrefour du pic Ordachaï à Kroazen)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3734,12 +3748,13 @@
         "map_id": "1",
         "markerend_id": "96",
         "markerstart_id": "171",
-        "modified": "20150909192326523",
+        "modified": "20151005183430512",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Terkhên à Melwan",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3750,12 +3765,13 @@
         "map_id": "1",
         "markerend_id": "47",
         "markerstart_id": "55",
-        "modified": "20150724202442146",
+        "modified": "20151005183430512",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Terkhên à Tulg Naomh",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3766,12 +3782,13 @@
         "map_id": "1",
         "markerend_id": "127",
         "markerstart_id": "55",
-        "modified": "20150906134609462",
+        "modified": "20151005183430512",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Terkhên au Col de Lochre",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3782,12 +3799,13 @@
         "map_id": "1",
         "markerend_id": "160",
         "markerstart_id": "167",
-        "modified": "20150906120051461",
+        "modified": "20151005183430522",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Tùrsal (des Salicornes au carrefour d'Eaux-Salées)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3798,12 +3816,13 @@
         "map_id": "1",
         "markerend_id": "160",
         "markerstart_id": "123",
-        "modified": "20150906120314619",
+        "modified": "20151005183430515",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers la Citadelle de Dèas",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3814,12 +3833,13 @@
         "map_id": "1",
         "markerend_id": "133",
         "markerstart_id": "160",
-        "modified": "20150906115904784",
+        "modified": "20151005183430522",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Tùrsal (du carrefour d'Eaux-Salées à Louarn)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3830,12 +3850,13 @@
         "map_id": "1",
         "markerend_id": "63",
         "markerstart_id": "115",
-        "modified": "20150724203540976",
+        "modified": "20151005183430520",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Brégan à Koskan",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3846,12 +3867,13 @@
         "map_id": "1",
         "markerend_id": "8",
         "markerstart_id": "115",
-        "modified": "20150904194504834",
+        "modified": "20151005183430520",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Brégan à Osta-Baille",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3863,12 +3885,13 @@
         "map_id": "1",
         "markerend_id": "23",
         "markerstart_id": "18",
-        "modified": "20150720200826290",
+        "modified": "20151005183430506",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin d'Afalinn",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3879,12 +3902,13 @@
         "map_id": "1",
         "markerend_id": "35",
         "markerstart_id": "34",
-        "modified": "20150904194456118",
+        "modified": "20151005183430520",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Crail à Gline",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3895,12 +3919,13 @@
         "map_id": "1",
         "markerend_id": "73",
         "markerstart_id": "132",
-        "modified": "20150724204503998",
+        "modified": "20151005183430520",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Kaer Daegis à Kel Loar",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3911,12 +3936,13 @@
         "map_id": "1",
         "markerend_id": "72",
         "markerstart_id": "132",
-        "modified": "20150724204659630",
+        "modified": "20151005183430520",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Kaer Daegis à Seòl",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3927,12 +3953,13 @@
         "map_id": "1",
         "markerend_id": "11",
         "markerstart_id": "73",
-        "modified": "20150724204822323",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Kel Loar au Pont de l'Alliance",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Le développement de cette route reliant Farl à Kell est un enjeu économique pour cette dernière.",
@@ -3943,12 +3970,13 @@
         "map_id": "1",
         "markerend_id": "21",
         "markerstart_id": "110",
-        "modified": "20150724205411022",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Kell à Farl",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3959,12 +3987,13 @@
         "map_id": "1",
         "markerend_id": "35",
         "markerstart_id": "62",
-        "modified": "20150724205623196",
+        "modified": "20151005183430522",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du Carrefour de Ruel à Gline",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -3975,12 +4004,13 @@
         "map_id": "1",
         "markerend_id": "60",
         "markerstart_id": "62",
-        "modified": "20150724205632999",
+        "modified": "20151005183430522",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du Carrefour de Ruel à Mùdan",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Cette route relie Kermordhran au Clos-des-Cendres. Des angardes bien entretenues la jalonnent, et des patrouilles la parcourent régulièrement.",
@@ -3992,12 +4022,13 @@
         "map_id": "1",
         "markerend_id": "108",
         "markerstart_id": "22",
-        "modified": "20150906140022220",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de la mer (de Kermordhran au carrefour du cirque d'Argoneskan)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Cette route qui relie Fionnfuar et Farl, dont les habitants l'appellent aussi \"Route de l'ouest\" ou \"Route marine\", est moins développée du côté gwidrite.",
@@ -4009,12 +4040,13 @@
         "map_id": "1",
         "markerend_id": "174",
         "markerstart_id": "20",
-        "modified": "20150909192520433",
+        "modified": "20151005183430520",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Farl",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Aussi appelé \"passage des Brumes\", ce sentier est la plus ancienne voie connue pour traverser les montagnes, aussi spectaculaire que dangereuse.",
@@ -4025,12 +4057,13 @@
         "map_id": "1",
         "markerend_id": "159",
         "markerstart_id": "158",
-        "modified": "20150829140648564",
+        "modified": "20151005183430524",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier d'Aisir Ceòmhor",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4043,12 +4076,13 @@
         "markerend_id": "125",
         "markerparent_id": "",
         "markerstart_id": "158",
-        "modified": "20150827100559590",
+        "modified": "20151005183430507",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin d'Aisir Ceòmhor au col de l'Artz",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4059,12 +4093,13 @@
         "map_id": "1",
         "markerend_id": "130",
         "markerstart_id": "84",
-        "modified": "20150823071413940",
+        "modified": "20151005183430508",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Cardach à la Brèche du loup",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4075,12 +4110,13 @@
         "map_id": "1",
         "markerend_id": "49",
         "markerstart_id": "48",
-        "modified": "20150823075837942",
+        "modified": "20151005183430508",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Dearg à Fearìl",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4091,12 +4127,13 @@
         "map_id": "1",
         "markerend_id": "51",
         "markerstart_id": "48",
-        "modified": "20150823075916987",
+        "modified": "20151005183430508",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Dearg à Loch Varn",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4109,12 +4146,13 @@
         "markerend_id": "159",
         "markerparent_id": "",
         "markerstart_id": "75",
-        "modified": "20150829140752858",
+        "modified": "20151005183430524",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier de Didean à Aisir Ceòmhor",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4125,12 +4163,13 @@
         "map_id": "1",
         "markerend_id": "50",
         "markerstart_id": "49",
-        "modified": "20150823075343957",
+        "modified": "20151005183430508",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Fearìl à la forteresse de Smiorail",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4142,12 +4181,13 @@
         "markerend_id": "142",
         "markerparent_id": "",
         "markerstart_id": "30",
-        "modified": "20150823081812342",
+        "modified": "20151005183430509",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de l'abbaye de Corvus à la route du Dorchwald",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4158,12 +4198,13 @@
         "map_id": "1",
         "markerend_id": "92",
         "markerstart_id": "130",
-        "modified": "20150823071547115",
+        "modified": "20151005183430509",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de la Brèche du loup à Deanaidh",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4176,12 +4217,13 @@
         "markerend_id": "126",
         "markerparent_id": "",
         "markerstart_id": "50",
-        "modified": "20150827095430138",
+        "modified": "20151005183430509",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de la forteresse de Smiorail au Col de Lantrech",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4192,12 +4234,13 @@
         "map_id": "1",
         "markerend_id": "71",
         "markerstart_id": "116",
-        "modified": "20150906121925109",
+        "modified": "20151005183430514",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour gwidrite d'Aelwyd Saogh à Expiation",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4208,12 +4251,13 @@
         "map_id": "1",
         "markerend_id": "52",
         "markerstart_id": "51",
-        "modified": "20150823075750178",
+        "modified": "20151005183430509",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Loch Varn au Col d'Oerdh",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4224,12 +4268,13 @@
         "map_id": "1",
         "markerend_id": "48",
         "markerstart_id": "96",
-        "modified": "20150823080225728",
+        "modified": "20151005183430510",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Melwan à Dearg",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4240,12 +4285,13 @@
         "map_id": "1",
         "markerend_id": "51",
         "markerstart_id": "96",
-        "modified": "20150823075708850",
+        "modified": "20151005183430510",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Melwan à Loch Varn",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Ce chemin permet de joindre Nectan à Deh'ad. Moins utilisé que la célèbre Voie sainte, il suit la lisière entre la forêt du Dorchwald et les contreforts des Mòr Roimh.",
@@ -4257,12 +4303,13 @@
         "map_id": "1",
         "markerend_id": "28",
         "markerstart_id": "26",
-        "modified": "20150717213352032",
+        "modified": "20151005183430523",
         "routetype_id": "1",
         "status": "done",
         "tags": "routes",
         "title": "Route du Dorchwald (de Nectan à Lenbach)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4275,12 +4322,13 @@
         "markerend_id": "56",
         "markerparent_id": "",
         "markerstart_id": "171",
-        "modified": "20150909192309757",
+        "modified": "20151005183430511",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Terkhên à Frendian",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4293,12 +4341,13 @@
         "markerend_id": "85",
         "markerparent_id": "",
         "markerstart_id": "52",
-        "modified": "20150906123006571",
+        "modified": "20151005183430514",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du col d'Oerdh à la route des Hilderins",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4310,12 +4359,13 @@
         "markerend_id": "141",
         "markerparent_id": "",
         "markerstart_id": "125",
-        "modified": "20150823090403767",
+        "modified": "20151005183430514",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du col de l'Artz à Tilliarch",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4326,12 +4376,13 @@
         "map_id": "1",
         "markerend_id": "id_Aisir Ceòmhor (est)",
         "markerstart_id": "127",
-        "modified": "20150823095727157",
+        "modified": "20151005183430514",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du col de Lochre à Aisir Ceòmhor",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4344,12 +4395,13 @@
         "markerend_id": "94",
         "markerparent_id": "",
         "markerstart_id": "117",
-        "modified": "20150823071031558",
+        "modified": "20151005183430515",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers Jarnel",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4362,12 +4414,13 @@
         "markerend_id": "120",
         "markerparent_id": "",
         "markerstart_id": "9",
-        "modified": "20150823090037614",
+        "modified": "20151005183430516",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers les carrières d'Arden",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4378,12 +4431,13 @@
         "map_id": "1",
         "markerend_id": "105",
         "markerstart_id": "72",
-        "modified": "20150823095208140",
+        "modified": "20151005183430516",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "De Seòl à Smàrag en char à voile",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4394,12 +4448,13 @@
         "map_id": "1",
         "markerend_id": "63",
         "markerstart_id": "105",
-        "modified": "20150823095217997",
+        "modified": "20151005183430516",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "De Smàrag à Koskan en char à voile",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4410,12 +4465,13 @@
         "map_id": "1",
         "markerend_id": "122",
         "markerstart_id": "92",
-        "modified": "20150823072823458",
+        "modified": "20151005183430520",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Piste des Roseaux",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4428,12 +4484,13 @@
         "markerend_id": "36",
         "markerparent_id": "",
         "markerstart_id": "34",
-        "modified": "20150823090629471",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Ouest (de Crail à Leacach)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Ce chemin poussiéreux mène, à travers un paysage accidenté, au manoir des Hauts-Vents.",
@@ -4445,12 +4502,13 @@
         "map_id": "1",
         "markerend_id": "31",
         "markerstart_id": "32",
-        "modified": "20150906125552888",
+        "modified": "20151005183430512",
         "routetype_id": "1",
         "status": "done",
         "tags": "routes",
         "title": "Chemin des Hauts-Vents",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Ce chemin permet de joindre Nectan à Deh'ad. Moins utilisé que la célèbre Voie sainte, il suit la lisière entre la forêt du Dorchwald et les contreforts des Mòr Roimh.",
@@ -4463,12 +4521,13 @@
         "markerend_id": "119",
         "markerparent_id": "",
         "markerstart_id": "142",
-        "modified": "20150827120416083",
+        "modified": "20151005183430523",
         "routetype_id": "1",
         "status": "done",
         "tags": "routes",
         "title": "Route du Dorchwald (du carrefour de Corvus au carrefour des Pierres Brisées)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Cette route, qui mène de Baldh-Ruoch à Kell en traversant la forêt de Taelwald, est un sujet de tension entre les magientistes, qui souhaiteraient la développer pour favoriser l'essor économique de Kell, et les demorthèn, qui veulent protéger la forêt.",
@@ -4479,12 +4538,13 @@
         "map_id": "1",
         "markerend_id": "147",
         "markerstart_id": "42",
-        "modified": "20150823085853637",
+        "modified": "20151005183430523",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du Taelwald (de Baldh-Ruoch au carrefour de l'Arbre de l'Automne)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Cette route, qui mène de Baldh-Ruoch à Kell en traversant la forêt de Taelwald, est un sujet de tension entre les magientistes, qui souhaiteraient la développer pour favoriser l'essor économique de Kell, et les demorthèn, qui veulent protéger la forêt.",
@@ -4496,12 +4556,13 @@
         "markerend_id": "110",
         "markerparent_id": "",
         "markerstart_id": "147",
-        "modified": "20150823085722713",
+        "modified": "20151005183430523",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du Taelwald (du carrefour de l'Arbre de l'Automne à Kell)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4513,12 +4574,13 @@
         "markerend_id": "112",
         "markerparent_id": "",
         "markerstart_id": "147",
-        "modified": "20150823085829292",
+        "modified": "20151005183430525",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier vers l'Arbre de l'Automne",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Comme le cours du Donir n'est pas navigable, une route longe le fleuve afin de rejoindre la capitale Baldh-Ruoch depuis le port d'Ear Caladh.",
@@ -4529,12 +4591,13 @@
         "map_id": "1",
         "markerend_id": "42",
         "markerstart_id": "41",
-        "modified": "20150823080653856",
+        "modified": "20151005183430526",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Donir (de Baldh-Ruoch à Ear Caladh)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4547,12 +4610,13 @@
         "markerend_id": "114",
         "markerparent_id": "",
         "markerstart_id": "53",
-        "modified": "20150823091831408",
+        "modified": "20151005183430526",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Kreizhdour (d'Arngyll au bac)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4565,12 +4629,13 @@
         "markerend_id": "128",
         "markerparent_id": "",
         "markerstart_id": "49",
-        "modified": "20150823091824034",
+        "modified": "20151005183430526",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Kreizhdour (de Fearìl au col de Siagal)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4581,12 +4646,13 @@
         "map_id": "1",
         "markerend_id": "164",
         "markerstart_id": "44",
-        "modified": "20150829150137901",
+        "modified": "20151005183430507",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Caiginn au carrefour de Thòl",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4599,12 +4665,13 @@
         "markerend_id": "167",
         "markerparent_id": "",
         "markerstart_id": "92",
-        "modified": "20150906115714641",
+        "modified": "20151005183430522",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Tùrsal (de Deanaidh aux Salicornes)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4617,12 +4684,13 @@
         "markerend_id": "57",
         "markerparent_id": "",
         "markerstart_id": "113",
-        "modified": "20150906123454858",
+        "modified": "20151005183430513",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du bac du Kreizhdour à Mambrun",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Les ouvriers qui empruntent ce chemin pour travailler aux mines de Promesse sont escortés par des hommes d'armes, en raison des raids fréquents menés par les clans osags.",
@@ -4633,12 +4701,13 @@
         "map_id": "1",
         "markerend_id": "38",
         "markerstart_id": "37",
-        "modified": "20150717214208294",
+        "modified": "20151005183430513",
         "routetype_id": "1",
         "status": "done",
         "tags": "routes",
         "title": "Chemin des mines de Promesse",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4651,12 +4720,13 @@
         "markerend_id": "164",
         "markerparent_id": "",
         "markerstart_id": "145",
-        "modified": "20150829145608589",
+        "modified": "20151005183430512",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Thòl au carrefour de Thòl",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Cette ancienne route traverse la forêt des Soupirs et permet de rejoindre Terkhên.",
@@ -4669,12 +4739,13 @@
         "markerend_id": "55",
         "markerparent_id": "",
         "markerstart_id": "163",
-        "modified": "20150829145843424",
+        "modified": "20151005183430513",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour de Laräch à Terkhên",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4687,12 +4758,13 @@
         "markerend_id": "71",
         "markerparent_id": "",
         "markerstart_id": "164",
-        "modified": "20150829150055903",
+        "modified": "20151005183430513",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour de Thòl à Expiation",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4705,12 +4777,13 @@
         "markerend_id": "145",
         "markerparent_id": "",
         "markerstart_id": "126",
-        "modified": "20150829145426245",
+        "modified": "20151005183430514",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du col de Lantrech à Thòl",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4723,12 +4796,13 @@
         "markerend_id": "131",
         "markerparent_id": "",
         "markerstart_id": "161",
-        "modified": "20150829150439451",
+        "modified": "20151005183430515",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers Gleb",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4741,12 +4815,13 @@
         "markerend_id": "54",
         "markerparent_id": "",
         "markerstart_id": "162",
-        "modified": "20150829154310884",
+        "modified": "20151005183430515",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers Helefrt",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4759,12 +4834,13 @@
         "markerend_id": "124",
         "markerparent_id": "",
         "markerstart_id": "22",
-        "modified": "20150829150246367",
+        "modified": "20151005183430515",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers la citadelle de Kermordhran",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4777,12 +4853,13 @@
         "markerend_id": "165",
         "markerparent_id": "",
         "markerstart_id": "160",
-        "modified": "20150829142823656",
+        "modified": "20151005183430515",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers le château des Mac Readan",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4795,12 +4872,13 @@
         "markerend_id": "166",
         "markerparent_id": "",
         "markerstart_id": "70",
-        "modified": "20150829142924179",
+        "modified": "20151005183430516",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers le château des Mac Tremen",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4813,12 +4891,13 @@
         "markerend_id": "58",
         "markerparent_id": "",
         "markerstart_id": "42",
-        "modified": "20150829150352693",
+        "modified": "20151005183430516",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers le château des Roharën",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4831,12 +4910,13 @@
         "markerend_id": "134",
         "markerparent_id": "",
         "markerstart_id": "145",
-        "modified": "20150831200726565",
+        "modified": "20151005183430516",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers le monastère de Tuath",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4849,12 +4929,13 @@
         "markerend_id": "82",
         "markerparent_id": "",
         "markerstart_id": "167",
-        "modified": "20150906115949241",
+        "modified": "20151005183430516",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers les alignements de Tùrsal",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4867,12 +4948,13 @@
         "markerend_id": "137",
         "markerparent_id": "",
         "markerstart_id": "98",
-        "modified": "20150829182639008",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de la côte d'Émeraude (de Nua Caladh au pont de Brian'ch)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4885,12 +4967,13 @@
         "markerend_id": "39",
         "markerparent_id": "",
         "markerstart_id": "161",
-        "modified": "20150829154210634",
+        "modified": "20151005183430523",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du Grand Est (du carrefour de Gleb à Iolairnead)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4903,12 +4986,13 @@
         "markerend_id": "16",
         "markerparent_id": "",
         "markerstart_id": "23",
-        "modified": "20150829182220252",
+        "modified": "20151005183430523",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route royale (d'Afalinn au pont sur le Donir de Kember)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4921,12 +5005,13 @@
         "markerend_id": "23",
         "markerparent_id": "",
         "markerstart_id": "118",
-        "modified": "20150829181925636",
+        "modified": "20151005183430524",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route royale (du carrefour de Promesse à Afalinn)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4939,12 +5024,13 @@
         "markerend_id": "42",
         "markerparent_id": "42",
         "markerstart_id": "137",
-        "modified": "20150829181340923",
+        "modified": "20151005183430524",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route royale (du pont de Brian'ch à Baldh-Ruoch)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4957,12 +5043,13 @@
         "markerend_id": "54",
         "markerparent_id": "",
         "markerstart_id": "57",
-        "modified": "20150829143822132",
+        "modified": "20151005183430525",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier de Mambrun à Helefrt",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4975,12 +5062,13 @@
         "markerend_id": "43",
         "markerparent_id": "",
         "markerstart_id": "163",
-        "modified": "20150829144847085",
+        "modified": "20151005183430525",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier vers les ruines du château des Mac Farquam",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -4993,12 +5081,13 @@
         "markerend_id": "15",
         "markerparent_id": "",
         "markerstart_id": "22",
-        "modified": "20150829153014203",
+        "modified": "20151005183430525",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie de l'Oëss (de Kermordhran à Kember)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5011,12 +5100,13 @@
         "markerend_id": "42",
         "markerparent_id": "",
         "markerstart_id": "17",
-        "modified": "20150829205354833",
+        "modified": "20151005183430526",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Donir (du pont sur l'Oëss de Kember à Baldh-Ruoch)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5029,12 +5119,13 @@
         "markerend_id": "163",
         "markerparent_id": "",
         "markerstart_id": "140",
-        "modified": "20150829144458848",
+        "modified": "20151005183430526",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Kreizhdour (de Telh au carrefour de Laräch)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5047,12 +5138,13 @@
         "markerend_id": "140",
         "markerparent_id": "",
         "markerstart_id": "162",
-        "modified": "20150829144403790",
+        "modified": "20151005183430526",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Kreizhdour (du carrefour d'Helefrt à Telh)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5065,12 +5157,13 @@
         "markerend_id": "53",
         "markerparent_id": "",
         "markerstart_id": "163",
-        "modified": "20150829144547498",
+        "modified": "20151005183430526",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Kreizhdour (du carrefour de Laräch à Arngyll)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5083,12 +5176,13 @@
         "markerend_id": "162",
         "markerparent_id": "",
         "markerstart_id": "128",
-        "modified": "20150829144247388",
+        "modified": "20151005183430526",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Voie du Kreizhdour (du col de Siagal au carrefour d'Helefrt)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5101,17 +5195,18 @@
         "markerend_id": "177",
         "markerparent_id": "",
         "markerstart_id": "7",
-        "modified": "20150909191905135",
+        "modified": "20151005183430505",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Canal des marécages gris (de Tuaille au carrefour du sud de Déas)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
+        "created": "20150906134218571",
         "text": "",
         "categorie": "cartographie",
-        "created": "20150906134218571",
         "faction_id": "",
         "id": "206",
         "itineraire": "",
@@ -5119,12 +5214,13 @@
         "markerend_id": "175",
         "markerparent_id": "",
         "markerstart_id": "135",
-        "modified": "20150909192056961",
+        "modified": "20151005191131389",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Canal des marécages gris d'Ostreach",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5137,12 +5233,13 @@
         "markerend_id": "175",
         "markerparent_id": "",
         "markerstart_id": "84",
-        "modified": "20150909192039777",
+        "modified": "20151005183430505",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Canal des marécages gris de Cardach",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5155,12 +5252,13 @@
         "markerend_id": "175",
         "markerparent_id": "",
         "markerstart_id": "79",
-        "modified": "20150909192026955",
+        "modified": "20151005183430506",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Canal des marécages gris de Merieren",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5173,12 +5271,13 @@
         "markerend_id": "175",
         "markerparent_id": "",
         "markerstart_id": "7",
-        "modified": "20150909192014030",
+        "modified": "20151005183430506",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Canal des marécages gris de Tuaille",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "La Voie sainte relie la capitale gwidrite, Ard-Amrach, à la ville sainte de Fionnfuar.",
@@ -5190,12 +5289,13 @@
         "map_id": "1",
         "markerend_id": "26",
         "markerstart_id": "9",
-        "modified": "20150712193146210",
+        "modified": "20151005183430526",
         "routetype_id": "2",
         "status": "done",
         "tags": "routes",
         "title": "Voie sainte (d'Ard-Amrach à Nectan)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5208,12 +5308,13 @@
         "markerend_id": "175",
         "markerparent_id": "",
         "markerstart_id": "177",
-        "modified": "20150909191953930",
+        "modified": "20151005183430506",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Canal des marécages gris du sud de Déas",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5226,12 +5327,13 @@
         "markerend_id": "173",
         "markerparent_id": "",
         "markerstart_id": "8",
-        "modified": "20150909192121705",
+        "modified": "20151005183430507",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin d'Osta-Baille au carrefour de Calhtair",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5244,12 +5346,13 @@
         "markerend_id": "177",
         "markerparent_id": "",
         "markerstart_id": "84",
-        "modified": "20150909192136891",
+        "modified": "20151005183430508",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Cardach au carrefour du sud de Déas",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5262,12 +5365,13 @@
         "markerend_id": "69",
         "markerparent_id": "",
         "markerstart_id": "129",
-        "modified": "20150906132823608",
+        "modified": "20151005183430508",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Diinthër à Rhingal",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5280,12 +5384,13 @@
         "markerend_id": "176",
         "markerparent_id": "",
         "markerstart_id": "39",
-        "modified": "20150909192153860",
+        "modified": "20151005183430508",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Iolairnead au carrefour du Gouffre Carmin",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5298,12 +5403,13 @@
         "markerend_id": "172",
         "markerparent_id": "",
         "markerstart_id": "73",
-        "modified": "20150909192211659",
+        "modified": "20151005183430509",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Kel Loar au carrefour d'Eschen",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5316,12 +5422,13 @@
         "markerend_id": "176",
         "markerparent_id": "",
         "markerstart_id": "110",
-        "modified": "20150909192224839",
+        "modified": "20151005183430509",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Kell au carrefour du Gouffre Carmin",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5334,12 +5441,13 @@
         "markerend_id": "169",
         "markerparent_id": "",
         "markerstart_id": "36",
-        "modified": "20150906121808003",
+        "modified": "20151005183430509",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Leacach au carrefour reizhite vers Aelwyd Saogh",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5352,12 +5460,13 @@
         "markerend_id": "86",
         "markerparent_id": "",
         "markerstart_id": "57",
-        "modified": "20150906124250655",
+        "modified": "20151005183430510",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Mambrun au carrefour de l'adret des Gisants",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5370,12 +5479,13 @@
         "markerend_id": "173",
         "markerparent_id": "",
         "markerstart_id": "105",
-        "modified": "20150909192253757",
+        "modified": "20151005183430511",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Smàrag au carrefour de Calhtair",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5388,12 +5498,13 @@
         "markerend_id": "171",
         "markerparent_id": "",
         "markerstart_id": "55",
-        "modified": "20150909192341190",
+        "modified": "20151005183430512",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Terkhên au carrefour à l'est de Terkhên",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5406,12 +5517,13 @@
         "markerend_id": "44",
         "markerparent_id": "",
         "markerstart_id": "145",
-        "modified": "20150906120749189",
+        "modified": "20151005183430512",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Thòl à Caiginn",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5424,12 +5536,13 @@
         "markerend_id": "72",
         "markerparent_id": "",
         "markerstart_id": "172",
-        "modified": "20150909192403918",
+        "modified": "20151005183430513",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour d'Eschen à Seòl",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5442,12 +5555,13 @@
         "markerend_id": "78",
         "markerparent_id": "",
         "markerstart_id": "143",
-        "modified": "20150906132103603",
+        "modified": "20151005183430513",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour de Còmhlan à Iolach",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5460,12 +5574,13 @@
         "markerend_id": "143",
         "markerparent_id": "",
         "markerstart_id": "177",
-        "modified": "20150909192428199",
+        "modified": "20151005183430514",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour du sud de Déas au carrefour de Còmhlan",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5478,12 +5593,13 @@
         "markerend_id": "116",
         "markerparent_id": "",
         "markerstart_id": "169",
-        "modified": "20150906122047514",
+        "modified": "20151005183430514",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour reizhite au carrefour gwidrite d'Alwyd Saogh",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5496,12 +5612,13 @@
         "markerend_id": "170",
         "markerparent_id": "",
         "markerstart_id": "32",
-        "modified": "20150906125747211",
+        "modified": "20151005183430514",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du Gué Sanglant au carrefour entre Corvus et Kermordhran",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Après cinq siècles d'abandon, la route qui permettait au roi de Gwidre de se rendre à la citadelle d'Aelwyd Saogh n'est plus guère qu'un chemin que le temps et les éléments peuvent avoir rendu hasardeux.",
@@ -5512,12 +5629,13 @@
         "map_id": "1",
         "markerend_id": "80",
         "markerstart_id": "116",
-        "modified": "20150906121502163",
+        "modified": "20151005183430514",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin gwidrite vers Aelwyd Saogh",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5530,12 +5648,13 @@
         "markerend_id": "22",
         "markerparent_id": "",
         "markerstart_id": "170",
-        "modified": "20150906140934724",
+        "modified": "20151005183430514",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin reizhite de Corvus à Kermordhran",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Après cinq siècles d'abandon, la route qui permettait au roi de Reizh de se rendre à la citadelle d'Aelwyd Saogh n'est plus guère qu'un chemin que le temps et les éléments peuvent avoir rendu hasardeux.",
@@ -5546,12 +5665,13 @@
         "map_id": "1",
         "markerend_id": "80",
         "markerstart_id": "169",
-        "modified": "20150906121450552",
+        "modified": "20151005183430514",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin reizhite vers Aelwyd Saogh",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "La Voie sainte relie la capitale gwidrite, Ard-Amrach, à la ville sainte de Fionnfuar.",
@@ -5563,12 +5683,13 @@
         "map_id": "1",
         "markerend_id": "25",
         "markerstart_id": "26",
-        "modified": "20150712190722177",
+        "modified": "20151005183430527",
         "routetype_id": "2",
         "status": "done",
         "tags": "routes",
         "title": "Voie sainte (de Nectan à Gouvran)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Après cinq siècles d'abandon, la route qui permettait au roi de Taol-Kaer de se rendre à la citadelle d'Aelwyd Saogh n'est plus guère qu'un chemin que le temps et les éléments peuvent avoir rendu hasardeux.",
@@ -5581,12 +5702,13 @@
         "markerend_id": "90",
         "markerparent_id": "",
         "markerstart_id": "59",
-        "modified": "20150906121536208",
+        "modified": "20151005183430515",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin talkéride vers Aelwyd Saogh (d'Ard-Monach au col de Brorann)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Après cinq siècles d'abandon, la route qui permettait au roi de Taol-Kaer de se rendre à la citadelle d'Aelwyd Saogh n'est plus guère qu'un chemin que le temps et les éléments peuvent avoir rendu hasardeux.",
@@ -5597,12 +5719,13 @@
         "map_id": "1",
         "markerend_id": "80",
         "markerstart_id": "90",
-        "modified": "20150906121525614",
+        "modified": "20151005183430515",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin talkéride vers Aelwyd Saogh (du col de Brorann à Aelwyd Saogh)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5615,12 +5738,13 @@
         "markerend_id": "91",
         "markerparent_id": "",
         "markerstart_id": "143",
-        "modified": "20150906132218079",
+        "modified": "20151005183430515",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin vers Còmhlan",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5633,12 +5757,13 @@
         "markerend_id": "30",
         "markerparent_id": "",
         "markerstart_id": "32",
-        "modified": "20150906124818040",
+        "modified": "20151005183430520",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Gwidre (du Gué Sanglant à l'abbaye de Corvus)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5651,12 +5776,13 @@
         "markerend_id": "174",
         "markerparent_id": "",
         "markerstart_id": "19",
-        "modified": "20150909192605188",
+        "modified": "20151005183430523",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route marine (du Clos-des-Cendres au carrefour des Cendres)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5669,12 +5795,13 @@
         "markerend_id": "66",
         "markerparent_id": "",
         "markerstart_id": "67",
-        "modified": "20150906135022684",
+        "modified": "20151005183430524",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier côtier de Calvaire (de Saint Arpan à Sainte Nihesk)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5687,12 +5814,13 @@
         "markerend_id": "64",
         "markerparent_id": "",
         "markerstart_id": "65",
-        "modified": "20150906135203577",
+        "modified": "20151005183430524",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier côtier de Calvaire (de Saint Heskenen à Saint Persked)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5705,12 +5833,13 @@
         "markerend_id": "65",
         "markerparent_id": "",
         "markerstart_id": "66",
-        "modified": "20150906135120805",
+        "modified": "20151005183430524",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier côtier de Calvaire (de Sainte Nihesk à Saint Heskenen)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5723,12 +5852,13 @@
         "markerend_id": "67",
         "markerparent_id": "",
         "markerstart_id": "100",
-        "modified": "20150906135405980",
+        "modified": "20151005183430524",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier côtier de Calvaire (du phare sud à Saint Arpan)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5741,12 +5871,13 @@
         "markerend_id": "8",
         "markerparent_id": "",
         "markerstart_id": "56",
-        "modified": "20150906141134653",
+        "modified": "20151005183430524",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier de Frendian à Osta-Baille",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "La Voie sainte relie la capitale gwidrite, Ard-Amrach, à la ville sainte de Fionnfuar.",
@@ -5758,12 +5889,13 @@
         "map_id": "1",
         "markerend_id": "27",
         "markerstart_id": "25",
-        "modified": "20150717214521390",
+        "modified": "20151005183430527",
         "routetype_id": "2",
         "status": "done",
         "tags": "routes",
         "title": "Voie sainte (de Gouvran à Deh'ad)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5776,12 +5908,13 @@
         "markerend_id": "106",
         "markerparent_id": "",
         "markerstart_id": "103",
-        "modified": "20150906135734817",
+        "modified": "20151005183430525",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier de la source aux Fols",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5794,12 +5927,13 @@
         "markerend_id": "132",
         "markerparent_id": "",
         "markerstart_id": "173",
-        "modified": "20150909192631008",
+        "modified": "20151005183430525",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier du carrefour de Calhtair et Kaer Daegis",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5812,12 +5946,13 @@
         "markerend_id": "74",
         "markerparent_id": "",
         "markerstart_id": "172",
-        "modified": "20150909192650849",
+        "modified": "20151005183430525",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier vers l'îlot d'Eschen",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5829,12 +5964,13 @@
         "map_id": "1",
         "markerend_id": "32",
         "markerstart_id": "18",
-        "modified": "20150906125319065",
+        "modified": "20151005183430520",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Gwidre (du château des Mac Emmanon au Gué Sanglant)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5846,12 +5982,13 @@
         "map_id": "1",
         "markerend_id": "118",
         "markerstart_id": "33",
-        "modified": "20150829181854296",
+        "modified": "20151005183430524",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route royale (de la demeure des Mac Baellec au carrefour de Promesse)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Les seigneurs du Croissant d'Émeraude imposent de nombreuses taxes le long de cette route, et ils n'hésitent pas à infliger des vexations aux voyageurs liées à la couronne reizhite, aussi bien marchands que magientistes.",
@@ -5862,12 +5999,13 @@
         "map_id": "1",
         "markerend_id": "98",
         "markerstart_id": "14",
-        "modified": "20150831202646730",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de la côte d'Émeraude (du carrefour de l'entrée du Reizh à Nua Caladh)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5878,12 +6016,13 @@
         "map_id": "1",
         "markerend_id": "34",
         "markerstart_id": "13",
-        "modified": "20150823090733855",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Ouest (de Kalvernach à Crail)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Cette route est très fréquentée par les chevaliers hilderins, notamment entre Osta-Baille et Ard-Monach. Au-delà, vers Caiginn, la route n'est pas toujours pavée.",
@@ -5895,12 +6034,13 @@
         "map_id": "1",
         "markerend_id": "44",
         "markerstart_id": "85",
-        "modified": "20150906122554079",
+        "modified": "20151005183430522",
         "routetype_id": "1",
         "status": "done",
         "tags": "routes",
         "title": "Route des Hilderins (du carrefour de Frendian à Caiginn)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -5911,12 +6051,13 @@
         "map_id": "1",
         "markerend_id": "161",
         "markerstart_id": "21",
-        "modified": "20150829154150859",
+        "modified": "20151005183430523",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route du Grand Est (de Farl au carrefour de Gleb)",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57",
+        "guarded": "false"
     },
     {
         "text": "La longue piste qui mène au col de Gaos-Bodhar n'est pas entretenue, et ce voyage aux confins de la péninsule vers le Continent est aussi ardu que périlleux.",
@@ -5927,12 +6068,13 @@
         "map_id": "1",
         "markerend_id": "40",
         "markerstart_id": "39",
-        "modified": "20150714102820350",
+        "modified": "20151005183430520",
         "routetype_id": "3",
         "status": "done",
         "tags": "routes",
         "title": "Piste de l'ours blanc",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Bien que ce village pourrait être une étape sur les routes maritimes commerciales qui longent prudemment les côtes, les navigateurs évitent de relâcher à Aimliù dont les habitants ont sinistre réputation.",
@@ -5943,12 +6085,13 @@
         "map_id": "1",
         "markerend_id": "9",
         "markerstart_id": "10",
-        "modified": "20150720175718013",
+        "modified": "20151005183430517",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Aimliù - Ard-Amrach",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Les capitaines qui assurent cette liaison commerciale prennent garde à longer les côtes pour ne pas braver les flots déchaînés de l'Océan Furieux.",
@@ -5959,12 +6102,13 @@
         "map_id": "1",
         "markerend_id": "25",
         "markerstart_id": "9",
-        "modified": "20150712171548874",
+        "modified": "20151005183430517",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Ard-Amrach - Gouvran",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Le Clos-des-Cendres étant une ville dont l'existence sort petit à petit du secret, elle figure sur peu de cartes et toutes les voies maritimes n'y font pas escale. Il est assez fréquent qu'une banquise se forme en hiver.",
@@ -5975,12 +6119,13 @@
         "map_id": "1",
         "markerend_id": "139",
         "markerstart_id": "19",
-        "modified": "20150722194553435",
+        "modified": "20151005183430517",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Clos-des-Cendres - Farl",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Les capitaines qui ont des relations à Ear Caladh, dont les taxes portuaires sont moins élevées qu'à son nouveau voisin, privilégient cette liaison commerciale, assurée par des koggens à la belle saison, quelquefois jusqu'en automne. Aux abords de l'embouchure du Tealderoth, les marins se méfient des sirènes auxquelles sont attribuées des disparitions régulières.",
@@ -5991,12 +6136,13 @@
         "map_id": "1",
         "markerend_id": "11",
         "markerstart_id": "41",
-        "modified": "20150712170933979",
+        "modified": "20151005183430517",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Ear Caladh - Embouchure du Tealderoth",
-        "zoneparent_id": "36"
+        "zoneparent_id": "36",
+        "guarded": "false"
     },
     {
         "text": "Les capitaines qui assurent cette liaison commerciale prennent garde à longer les côtes pour ne pas braver les flots déchaînés de l'Océan Furieux.",
@@ -6007,12 +6153,13 @@
         "map_id": "1",
         "markerend_id": "45",
         "markerstart_id": "93",
-        "modified": "20150712171858471",
+        "modified": "20151005183430517",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Embouchure du Kreizhdour - Gorm Caladh",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Des koggens assurent régulièrement cette liaison commerciale, mais seulement à la belle saison, quelquefois jusqu'en automne. Aux abords de l'embouchure du Tealderoth, les marins se méfient des sirènes auxquelles sont attribuées des disparitions régulières.",
@@ -6023,12 +6170,13 @@
         "map_id": "1",
         "markerend_id": "73",
         "markerstart_id": "11",
-        "modified": "20150712170747431",
+        "modified": "20151005183430517",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Embouchure du Tealderoth - Kel Loar",
-        "zoneparent_id": "36"
+        "zoneparent_id": "36",
+        "guarded": "false"
     },
     {
         "text": "Le Clos-des-Cendres étant une ville dont l'existence sort petit à petit du secret, elle figure sur peu de cartes et toutes les voies maritimes n'y font pas escale. Il est assez fréquent qu'une banquise se forme en hiver.",
@@ -6039,12 +6187,13 @@
         "map_id": "1",
         "markerend_id": "19",
         "markerstart_id": "20",
-        "modified": "20150720175738045",
+        "modified": "20151005183430517",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Fionnfuar - Clos-des-Cendres",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Cette route pavée relie l'ancienne capitale, Tuaille, à la nouvelle, Osta-Baille. Entretenue tant bien que mal par la guilde des Paveurs, elle traverse les marécages gris et passe par la ville de Merieren, à l'embouchure du Klaedhin. Elle est très fréquentée par les voyageurs et les caravanes, bien que ceux qui peuvent se le payer préfèrent naviguer sur le cours tranquille du fleuve.",
@@ -6056,12 +6205,13 @@
         "map_id": "1",
         "markerend_id": "79",
         "markerstart_id": "7",
-        "modified": "20150711131037171",
+        "modified": "20151005183430522",
         "routetype_id": "2",
         "status": "done",
         "tags": "routes",
         "title": "Route des capitales (de Tuaille à Merieren)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Les capitaines qui assurent cette liaison commerciale prennent garde à longer les côtes pour ne pas braver les flots déchaînés de l'Océan Furieux. Le Clos-des-Cendres étant une ville dont l'existence sort petit à petit du secret, elle figure sur peu de cartes et toutes les voies maritimes n'y font pas escale. Il est assez fréquent qu'une banquise se forme en hiver.",
@@ -6072,12 +6222,13 @@
         "map_id": "1",
         "markerend_id": "139",
         "markerstart_id": "20",
-        "modified": "20150722194545006",
+        "modified": "20151005183430517",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Fionnfuar - Farl",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Bien que ce village pourrait être une étape sur les routes maritimes commerciales qui longent prudemment les côtes, les navigateurs évitent de relâcher à Aimliù dont les habitants ont sinistre réputation.",
@@ -6088,12 +6239,13 @@
         "map_id": "1",
         "markerend_id": "10",
         "markerstart_id": "45",
-        "modified": "20150720175651400",
+        "modified": "20151005183430518",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Gorm Caladh - Aimliù",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Les capitaines qui assurent cette liaison commerciale prennent garde à longer les côtes pour ne pas braver les flots déchaînés de l'Océan Furieux, et évitent de relâcher à Aimliù dont les habitants ont sinistre réputation.",
@@ -6104,12 +6256,13 @@
         "map_id": "1",
         "markerend_id": "9",
         "markerstart_id": "45",
-        "modified": "20150720175644509",
+        "modified": "20151005183430518",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Gorm Caladh - Ard-Amrach",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Les capitaines qui assurent cette liaison commerciale prennent garde à longer les côtes pour ne pas braver les flots déchaînés de l'Océan Furieux. Lors des hivers les plus froids, une banquise peut se former.",
@@ -6120,12 +6273,13 @@
         "map_id": "1",
         "markerend_id": "20",
         "markerstart_id": "25",
-        "modified": "20150712171506966",
+        "modified": "20151005183430518",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Gouvran - Fionnfuar",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Des koggens assurent régulièrement cette liaison commerciale, mais seulement à la belle saison, quelquefois jusqu'en automne.",
@@ -6136,12 +6290,13 @@
         "map_id": "1",
         "markerend_id": "72",
         "markerstart_id": "73",
-        "modified": "20150712165554687",
+        "modified": "20151005183430518",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Kel Loar - Seòl",
-        "zoneparent_id": "36"
+        "zoneparent_id": "36",
+        "guarded": "false"
     },
     {
         "text": "Les bateaux qui empruntent cette liaison maritime sont peu nombreux.",
@@ -6152,12 +6307,13 @@
         "map_id": "1",
         "markerend_id": "7",
         "markerstart_id": "63",
-        "modified": "20150712165300197",
+        "modified": "20151005183430518",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Koskan - Tuaille",
-        "zoneparent_id": "36"
+        "zoneparent_id": "36",
+        "guarded": "false"
     },
     {
         "text": "Cette voie maritime permet au duché de Tulg d'exporter ses ressources minières et son bois. Le phare de Tulg Naomh est un point de repère très connu pour les navigateurs.",
@@ -6168,12 +6324,13 @@
         "map_id": "1",
         "markerend_id": "47",
         "markerstart_id": "70",
-        "modified": "20150712165034103",
+        "modified": "20151005183430518",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Llewellen - Tulg Naomh",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Bien que plus lourdement taxée qu'à l'ancien port d'Ear Caladh devenu trop petit, cette liaison commerciale est la plus fréquente. Elle n'est assurée par des koggens qu'à la belle saison, quelquefois jusqu'en automne. Aux abords de l'embouchure du Tealderoth, les marins se méfient des sirènes auxquelles sont attribuées des disparitions régulières.",
@@ -6184,12 +6341,13 @@
         "map_id": "1",
         "markerend_id": "11",
         "markerstart_id": "98",
-        "modified": "20150712170726093",
+        "modified": "20151005183430518",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Nua Caladh - Embouchure du Tealderoth",
-        "zoneparent_id": "36"
+        "zoneparent_id": "36",
+        "guarded": "false"
     },
     {
         "text": "Seuls les plus gros chargements de fret sont encore transportés par cette voie maritime, qui est concurrencée par les chars à voile qui acheminent bien plus rapidement et sûrement les passagers et les marchandises plus légères à travers les Grandes Plages.",
@@ -6200,12 +6358,13 @@
         "map_id": "1",
         "markerend_id": "105",
         "markerstart_id": "72",
-        "modified": "20150712165522267",
+        "modified": "20151005183430518",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Seòl - Smàrag",
-        "zoneparent_id": "36"
+        "zoneparent_id": "36",
+        "guarded": "false"
     },
     {
         "text": "Seuls les plus gros chargements de fret sont encore transportés par cette voie maritime, qui est concurrencée par les chars à voile qui acheminent bien plus rapidement et sûrement les passagers et les marchandises plus légères à travers les Grandes Plages.",
@@ -6216,12 +6375,13 @@
         "map_id": "1",
         "markerend_id": "63",
         "markerstart_id": "105",
-        "modified": "20150712165355063",
+        "modified": "20151005183430518",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Smàrag - Koskan",
-        "zoneparent_id": "36"
+        "zoneparent_id": "36",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -6232,12 +6392,13 @@
         "map_id": "1",
         "markerend_id": "14",
         "markerstart_id": "11",
-        "modified": "20150720200817276",
+        "modified": "20151005183430519",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Nord du Pont de l'Alliance",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57",
+        "guarded": "false"
     },
     {
         "text": "Rares sont les bateaux qui naviguent jusqu'à Iolach, ce port de pêche ayant mauvaise réputation.",
@@ -6248,12 +6409,13 @@
         "map_id": "1",
         "markerend_id": "78",
         "markerstart_id": "7",
-        "modified": "20150712165154058",
+        "modified": "20151005183430518",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Tuaille - Iolach",
-        "zoneparent_id": "36"
+        "zoneparent_id": "36",
+        "guarded": "false"
     },
     {
         "text": "Cette voie maritime permet au duché de Tulg d'exporter ses ressources minières et son bois. Le phare de Tulg Naomh est un point de repère très connu pour les navigateurs.",
@@ -6264,12 +6426,13 @@
         "map_id": "1",
         "markerend_id": "93",
         "markerstart_id": "47",
-        "modified": "20150712164953316",
+        "modified": "20151005183430518",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison Tulg Naomh - Embouchure du Kreizhdour",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Rejoindre Calvaire ne peut se faire qu'en caraque à la fin de l'été, en profitant dans les derniers jours de Lunasdal d'un puissant courant maritime depuis l'embouchure du Pezhdour vers le nord-ouest. À condition que le capitaine parvienne à mettre son navire sous le vent qui lui permettra de sortir du courant et d'accoster sur la pointe nord de l'île, sous peine de se diriger irrémédiablement vers le grand large !",
@@ -6281,12 +6444,13 @@
         "map_id": "1",
         "markerend_id": "68",
         "markerstart_id": "9",
-        "modified": "20150713080221951",
+        "modified": "20151005183430518",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de l'embouchure du Pezhdour au Roc)",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Si le capitaine de la caraque est parvenu sortir du courant vers le grand large pour rejoindre la pointe nord de l'île du Calvaire, il doit ensuite longer toute la côte ouest de l'île en évitant les écueils avant de pouvoir enfin passer la pointe sud et rejoindre des eaux relativement plus clémentes.",
@@ -6298,12 +6462,13 @@
         "map_id": "1",
         "markerend_id": "100",
         "markerstart_id": "99",
-        "modified": "20150712171248968",
+        "modified": "20151005183430519",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de la pointe ouest à la pointe sud)",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Depuis les eaux relativement plus clémentes de la côte est de l'île, il est possible de rallier les quatre villages-monastères et de revenir sur la péninsule vers Gorm Caladh.",
@@ -6315,12 +6480,13 @@
         "map_id": "1",
         "markerend_id": "45",
         "markerstart_id": "100",
-        "modified": "20150712171204751",
+        "modified": "20151005183430519",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de la pointe sud à Gorm Caladh)",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Une fois passée la pointe sud les eaux sont relativement plus clémentes. De là, il est possible de rallier les quatre villages-monastères et de revenir sur la péninsule vers Gorm Caladh.",
@@ -6332,12 +6498,13 @@
         "map_id": "1",
         "markerend_id": "67",
         "markerstart_id": "100",
-        "modified": "20150712170251652",
+        "modified": "20151005183430519",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de la pointe sud à Saint Arpan)",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Une fois passée la pointe sud les eaux sont relativement plus clémentes. De là, il est possible de rallier les quatre villages-monastères et de revenir sur la péninsule vers Gorm Caladh.",
@@ -6348,12 +6515,13 @@
         "map_id": "1",
         "markerend_id": "66",
         "markerstart_id": "67",
-        "modified": "20150712170037294",
+        "modified": "20151005183430519",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de Saint Arpan à Sainte Nihesk)",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Une fois passée la pointe sud les eaux sont relativement plus clémentes. De là, il est possible de rallier les quatre villages-monastères et de revenir sur la péninsule vers Gorm Caladh.",
@@ -6364,12 +6532,13 @@
         "map_id": "1",
         "markerend_id": "64",
         "markerstart_id": "65",
-        "modified": "20150712170122313",
+        "modified": "20151005183430519",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de Saint Heskenen à Saint Persked)",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Une fois passée la pointe sud les eaux sont relativement plus clémentes. De là, il est possible de rallier les quatre villages-monastères et de revenir sur la péninsule vers Gorm Caladh.",
@@ -6380,12 +6549,13 @@
         "map_id": "1",
         "markerend_id": "65",
         "markerstart_id": "66",
-        "modified": "20150712165920804",
+        "modified": "20151005183430519",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (de Sainte Nihesk à Saint Heskenen)",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Si le capitaine de la caraque est parvenu sortir du courant vers le grand large pour rejoindre la pointe nord de l'île du Calvaire, il doit ensuite longer toute la côte ouest de l'île en évitant les écueils avant de pouvoir enfin passer la pointe sud et rejoindre des eaux relativement plus clémentes.",
@@ -6397,12 +6567,13 @@
         "map_id": "1",
         "markerend_id": "99",
         "markerstart_id": "68",
-        "modified": "20150713080237558",
+        "modified": "20151005183430519",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Calvaire (du Roc à la pointe ouest)",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Ce chemin mène au promontoire où se trouve le sanctuaire demorthèn du \"belvédère de l'est\".",
@@ -6413,12 +6584,13 @@
         "map_id": "1",
         "markerend_id": "12",
         "markerstart_id": "14",
-        "modified": "20150711123628769",
+        "modified": "20151005183430515",
         "routetype_id": "1",
         "status": "done",
         "tags": "routes",
         "title": "Chemin vers Fairean Ear",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "La navigation vers les îles de l'archipel peut être compliquée par les conditions climatiques, oscillant fréquemment entre le froid hivernal et les diverses émanations volcaniques.",
@@ -6430,12 +6602,13 @@
         "map_id": "1",
         "markerend_id": "83",
         "markerstart_id": "19",
-        "modified": "20150712172635169",
+        "modified": "20151005183430519",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers l'Archipel des Cendres (depuis Clos-des-Cendres)",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "La navigation vers les îles de l'archipel peut être compliquée par les conditions climatiques, oscillant fréquemment entre le froid hivernal et les diverses émanations volcaniques.",
@@ -6447,12 +6620,13 @@
         "map_id": "1",
         "markerend_id": "102",
         "markerstart_id": "20",
-        "modified": "20150712170629639",
+        "modified": "20151005183430519",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers l'Archipel des Cendres (depuis Fionnfuar)",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Comme l'île est bordée de récifs, la seule période favorable pour y accoster est au début de l'été, entre la mi-Ogmhios et la fin de Luchar, quand les courants sont plus stables. Le reste de l'année, seuls quelques passeurs de Koskan, des fous qui disent s'être abreuvés à la source aux Fols, acceptent de faire la traversée.",
@@ -6463,12 +6637,13 @@
         "map_id": "1",
         "markerend_id": "103",
         "markerstart_id": "63",
-        "modified": "20150712170547075",
+        "modified": "20151005183430519",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers l'île aux Cairns",
-        "zoneparent_id": "36"
+        "zoneparent_id": "36",
+        "guarded": "false"
     },
     {
         "text": "La traversée vers l'archipel des Trois Sœurs s'effectue en caraque, et seulement à la belle saison et par temps clair, à cause des hauts-fonds. L'accostage ne peut se faire que sur la côte occidentale de l'île de Tir na Loch, où se trouve le port de Màn Atlach destiné aux échanges entre les Tri-Kazeliens et les îliens.",
@@ -6479,12 +6654,13 @@
         "map_id": "1",
         "markerend_id": "95",
         "markerstart_id": "73",
-        "modified": "20150712171409195",
+        "modified": "20151005183430519",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers les Tri-Sweszörs",
-        "zoneparent_id": "36"
+        "zoneparent_id": "36",
+        "guarded": "false"
     },
     {
         "text": "La traversée de Farl vers Mornegivre, sur l'océan Furieux où les tempêtes glaciales sont fréquentes, est par nature incertaine, et rares sont les capitaines qui accepteront d'y risquer leur caraque.",
@@ -6495,12 +6671,13 @@
         "map_id": "1",
         "markerend_id": "104",
         "markerstart_id": "139",
-        "modified": "20150722194537063",
+        "modified": "20151005183430519",
         "routetype_id": "4",
         "status": "done",
         "tags": "routes",
         "title": "Liaison vers Mornegivre",
-        "zoneparent_id": "40"
+        "zoneparent_id": "40",
+        "guarded": "false"
     },
     {
         "text": "Cette route pavée relie l'ancienne capitale, Tuaille, à la nouvelle, Osta-Baille. Entretenue tant bien que mal par la guilde des Paveurs, elle passe par Merieren, à l'embouchure du Klaedhin. Elle est très fréquentée par les voyageurs et les caravanes, bien que ceux qui peuvent se le payer préfèrent naviguer sur le cours tranquille du fleuve.",
@@ -6512,12 +6689,13 @@
         "map_id": "1",
         "markerend_id": "8",
         "markerstart_id": "79",
-        "modified": "20150827095548778",
+        "modified": "20151005183430522",
         "routetype_id": "2",
         "status": "done",
         "tags": "routes",
         "title": "Route des capitales (de Merieren à Osta-Baille)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Cette route est très fréquentée par les chevaliers hilderins, notamment entre Osta-Baille et Ard-Monach. Des brigands sévissent parfois autour de cette dernière. Au-delà, vers Caiginn, la route n'est pas toujours pavée.",
@@ -6529,12 +6707,13 @@
         "map_id": "1",
         "markerend_id": "85",
         "markerstart_id": "59",
-        "modified": "20150823085026791",
+        "modified": "20151005183430522",
         "routetype_id": "1",
         "status": "done",
         "tags": "routes",
         "title": "Route des Hilderins (d'Ard-Monach au carrefour de Frendian)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Cette route est très fréquentée par les chevaliers hilderins, notamment entre Osta-Baille et Ard-Monach.",
@@ -6546,12 +6725,13 @@
         "map_id": "1",
         "markerend_id": "60",
         "markerstart_id": "8",
-        "modified": "20150712195343407",
+        "modified": "20151005183430522",
         "routetype_id": "2",
         "status": "done",
         "tags": "routes",
         "title": "Route des Hilderins (d'Osta-Baille à Mùdan)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Cette route est très fréquentée par les chevaliers hilderins, notamment entre Osta-Baille et Ard-Monach. Des brigands sévissent parfois autour de cette dernière.",
@@ -6563,12 +6743,13 @@
         "map_id": "1",
         "markerend_id": "59",
         "markerstart_id": "60",
-        "modified": "20150714151146275",
+        "modified": "20151005183430522",
         "routetype_id": "2",
         "status": "done",
         "tags": "routes",
         "title": "Route des Hilderins (de Mùdan à Ard-Monach)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -6580,12 +6761,13 @@
         "map_id": "1",
         "markerend_id": "76",
         "markerstart_id": "78",
-        "modified": "20150909192809190",
+        "modified": "20151005183430525",
         "routetype_id": "3",
         "status": "à revoir",
         "tags": "routes",
         "title": "Sentier vers la pointe de Hòb",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -6596,12 +6778,13 @@
         "map_id": "1",
         "markerend_id": "14",
         "markerstart_id": "13",
-        "modified": "20150720200821353",
+        "modified": "20151005183430517",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Kalvernach est",
-        "zoneparent_id": "id_Royaume de Reizh"
+        "zoneparent_id": "57",
+        "guarded": "false"
     },
     {
         "text": "Des embarcations traversent l'embouchure du Donir, pour permettre notamment aux travailleurs du nouveau port, Nua Caladh, de se rendre à l'ancien port, Ear Caladh.",
@@ -6612,12 +6795,13 @@
         "map_id": "1",
         "markerend_id": "98",
         "markerstart_id": "41",
-        "modified": "20150712171319030",
+        "modified": "20151005183430525",
         "routetype_id": "5",
         "status": "done",
         "tags": "routes",
         "title": "Traversée Ear Caladh - Nua Caladh",
-        "zoneparent_id": "36"
+        "zoneparent_id": "36",
+        "guarded": "false"
     },
     {
         "text": "Cette route relie Expiation, l'un des principaux lieux de pèlerinage du royaume de Gwidre, à la capitale. Ce voyage, ponctué de monastères, est l'occasion de se purifier avant d'arriver à Ard-Amrach pour y participer à des cérémonies rituelles. C'est l'une des rares routes bien entretenues qui permettent de traverser en relative sécurité les dangereuses Mòr Roimh.",
@@ -6629,12 +6813,13 @@
         "map_id": "1",
         "markerend_id": "87",
         "markerstart_id": "71",
-        "modified": "20150906123722799",
+        "modified": "20151005183430525",
         "routetype_id": "2",
         "status": "done",
         "tags": "routes",
         "title": "Voie des pèlerins (d'Expiation au carrefour du pic Ordachaï)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Cette route relie Expiation, l'un des principaux lieux de pèlerinage du royaume de Gwidre, à la capitale. Ce voyage, ponctué de monastères, est l'occasion de se purifier avant d'arriver à Ard-Amrach pour y participer à des cérémonies rituelles.",
@@ -6646,12 +6831,13 @@
         "map_id": "1",
         "markerend_id": "9",
         "markerstart_id": "69",
-        "modified": "20150712193448641",
+        "modified": "20151005183430526",
         "routetype_id": "2",
         "status": "done",
         "tags": "routes",
         "title": "Voie des pèlerins (de Rhingal à Ard-Amrach)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -6663,12 +6849,13 @@
         "map_id": "1",
         "markerend_id": "71",
         "markerstart_id": "86",
-        "modified": "20150909192842993",
+        "modified": "20151005183430513",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin du carrefour de l'adret des Gisants à Expiation",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Cette route relie Expiation, l'un des principaux lieux de pèlerinage du royaume de Gwidre, à la capitale. Ce voyage, ponctué de monastères, est l'occasion de se purifier avant d'arriver à Ard-Amrach pour y participer à des cérémonies rituelles. C'est l'une des rares routes bien entretenues qui permettent de traverser en relative sécurité les dangereuses Mòr Roimh.",
@@ -6680,12 +6867,13 @@
         "map_id": "1",
         "markerend_id": "88",
         "markerstart_id": "87",
-        "modified": "20150823085122859",
+        "modified": "20151005183430526",
         "routetype_id": "2",
         "status": "done",
         "tags": "routes",
         "title": "Voie des pèlerins (du carrefour du pic Ordachaï au carrefour du pic Venteux)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Cette route relie Expiation, l'un des principaux lieux de pèlerinage du royaume de Gwidre, à la capitale. Ce voyage, ponctué de monastères, est l'occasion de se purifier avant d'arriver à Ard-Amrach pour y participer à des cérémonies rituelles. C'est l'une des rares routes bien entretenues qui permettent de traverser en relative sécurité les dangereuses Mòr Roimh.",
@@ -6697,12 +6885,13 @@
         "map_id": "1",
         "markerend_id": "69",
         "markerstart_id": "88",
-        "modified": "20150823085133422",
+        "modified": "20151005183430526",
         "routetype_id": "2",
         "status": "done",
         "tags": "routes",
         "title": "Voie des pèlerins (du carrefour du pic Venteux à Rhingal)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Ce chemin tortueux et abrupt permet de rejoindre la communauté autarcique de Haut-Mùdan. Il est surveillé de près et ses alentours sont piégés.",
@@ -6713,12 +6902,13 @@
         "map_id": "1",
         "markerend_id": "61",
         "markerstart_id": "60",
-        "modified": "20150714101339979",
+        "modified": "20151005183430510",
         "routetype_id": "1",
         "status": "done",
         "tags": "routes",
         "title": "Chemin de Mùdan au Haut-Mùdan",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Ce chemin permet de rejoindre Frendian depuis la route des Hilderins. Lorsque l'on pénètre dans le comté, les montagnes aux bois sombres s'ouvrent sur une vallée lumineuse et sereine.",
@@ -6729,12 +6919,13 @@
         "map_id": "1",
         "markerend_id": "56",
         "markerstart_id": "85",
-        "modified": "20150714150318172",
+        "modified": "20151005183430515",
         "routetype_id": "1",
         "status": "done",
         "tags": "routes",
         "title": "Chemin vers Frendian (depuis la route des Hilderins)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Cette route relie Kermordhran au Clos-des-Cendres. Des angardes bien entretenues la jalonnent, et des patrouilles la parcourent régulièrement.",
@@ -6746,12 +6937,13 @@
         "map_id": "1",
         "markerend_id": "174",
         "markerstart_id": "108",
-        "modified": "20150909192542856",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de la mer (du carrefour du cirque d'Argoneskan au carrefour des Cendres)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "La Voie sainte relie la capitale gwidrite, Ard-Amrach, à la ville sainte de Fionnfuar.",
@@ -6763,12 +6955,13 @@
         "map_id": "1",
         "markerend_id": "20",
         "markerstart_id": "27",
-        "modified": "20150717213339568",
+        "modified": "20151005183430526",
         "routetype_id": "2",
         "status": "done",
         "tags": "routes",
         "title": "Voie sainte (de Deh'ad à Fionnfuar)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Les deux ponts de Kember, nœuds de la stratégie royale pour le contrôle des infrastructures de transport, se rejoignent sur une vaste place de marché, encore en terre battue pour le moment.",
@@ -6779,12 +6972,13 @@
         "map_id": "1",
         "markerend_id": "17",
         "markerstart_id": "16",
-        "modified": "20150805121810747",
+        "modified": "20151005183430524",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Routes de Kember",
-        "zoneparent_id": "2"
+        "zoneparent_id": "2",
+        "guarded": "false"
     },
     {
         "text": "Ce chemin permet de joindre Nectan à Deh'ad. Moins utilisé que la célèbre Voie sainte, il suit la lisière entre la forêt du Dorchwald et les contreforts des Mòr Roimh.",
@@ -6796,12 +6990,13 @@
         "map_id": "1",
         "markerend_id": "142",
         "markerstart_id": "28",
-        "modified": "20150827120408056",
+        "modified": "20151005183430523",
         "routetype_id": "1",
         "status": "done",
         "tags": "routes",
         "title": "Route du Dorchwald (de Lenbach au carrefour de Corvus)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Ce chemin est le plus sûr permettant de relier Kell et Kermordhran à travers les montagnes hostiles. Tout le long de la piste, des clascadh, d'anciens abris en pierre en forme de dôme, permettent aux voyageurs de s'abriter du vent et du froid.",
@@ -6813,12 +7008,13 @@
         "map_id": "1",
         "markerend_id": "109",
         "markerstart_id": "110",
-        "modified": "20150717220105055",
+        "modified": "20151005183430523",
         "routetype_id": "1",
         "status": "done",
         "tags": "routes",
         "title": "Route Grise (de Kell au Château des Nevermore)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Ce chemin est le plus sûr permettant de relier Kell et Kermordhran à travers les montagnes hostiles. Tout le long de la piste, des clascadh, d'anciens abris en pierre en forme de dôme, permettent aux voyageurs de s'abriter du vent et du froid.",
@@ -6830,12 +7026,13 @@
         "map_id": "1",
         "markerend_id": "22",
         "markerstart_id": "109",
-        "modified": "20150720170158377",
+        "modified": "20151005183430523",
         "routetype_id": "1",
         "status": "done",
         "tags": "routes",
         "title": "Route Grise (du Château des Nevermore à Kermordhran)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Le sentier qui mène à l'adret des Gisants est interdit par des pancartes posées par les sigires. Les varigaux, prévenus par des stermerks, n'y montent plus, laissant leurs clients finir seuls l'ascension. Si le sentier est souvent environné de brumes, un temps ensoleillé révèle les ossements de tous ceux morts là.",
@@ -6846,12 +7043,13 @@
         "map_id": "1",
         "markerend_id": "107",
         "markerstart_id": "86",
-        "modified": "20150906124101286",
+        "modified": "20151005183430524",
         "routetype_id": "3",
         "status": "done",
         "tags": "routes",
         "title": "Sentier de l'adret des Gisants",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Ni demorthèn ni fidèles du Temple n'empruntent plus cet ancien chemin depuis la destruction du liagcal et l'abandon de l'église qui l'avait remplacé. Des stermerks, les signes utilisés par les varigaux, préviennent ces derniers des dangers du lieu.",
@@ -6863,12 +7061,13 @@
         "map_id": "1",
         "markerend_id": "29",
         "markerstart_id": "119",
-        "modified": "20150717214400501",
+        "modified": "20151005183430525",
         "routetype_id": "3",
         "status": "done",
         "tags": "routes",
         "title": "Sentier des Pierres Brisées",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Peu d'aventuriers empruntent cette sente pour se rendre dans le cirque d'Argoneskan.",
@@ -6880,12 +7079,13 @@
         "map_id": "1",
         "markerend_id": "24",
         "markerstart_id": "108",
-        "modified": "20150720170125511",
+        "modified": "20151005183430525",
         "routetype_id": "3",
         "status": "done",
         "tags": "routes",
         "title": "Sentier du cirque d'Argoneskan",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Ce sentier permet de se rendre au Monastère de Sainte Velathys, qui se tient à l'écart de la Voie des pèlerins, sur les flancs du pic Venteux.",
@@ -6896,12 +7096,13 @@
         "map_id": "1",
         "markerend_id": "97",
         "markerstart_id": "88",
-        "modified": "20150714103706452",
+        "modified": "20151005183430525",
         "routetype_id": "3",
         "status": "done",
         "tags": "routes",
         "title": "Sentier du Monastère du pic Venteux",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "Ce chemin permet de joindre Nectan à Deh'ad. Moins utilisé que la célèbre Voie sainte, il suit la lisière entre la forêt du Dorchwald et les contreforts des Mòr Roimh.",
@@ -6913,12 +7114,13 @@
         "map_id": "1",
         "markerend_id": "27",
         "markerstart_id": "119",
-        "modified": "20150723190920079",
+        "modified": "20151005183430523",
         "routetype_id": "1",
         "status": "done",
         "tags": "routes",
         "title": "Route du Dorchwald (du carrefour des Pierres Brisées à Deh'ad)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -6930,12 +7132,13 @@
         "map_id": "1",
         "markerend_id": "113",
         "markerstart_id": "114",
-        "modified": "20150723191015610",
+        "modified": "20151005183430505",
         "routetype_id": "5",
         "status": "à revoir",
         "tags": "routes",
         "title": "Bac de l'embouchure du Kreizhdour",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -6947,12 +7150,13 @@
         "map_id": "1",
         "markerend_id": "133",
         "markerstart_id": "75",
-        "modified": "20150723191103153",
+        "modified": "20151005183430508",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Didean à Louarn",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -6963,12 +7167,13 @@
         "map_id": "1",
         "markerend_id": "18",
         "markerstart_id": "16",
-        "modified": "20150906124939216",
+        "modified": "20151005183430520",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de Gwidre (du pont sur le Donir de Kember au château des Mac Emmanon)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -6980,12 +7185,13 @@
         "map_id": "1",
         "markerend_id": "75",
         "markerstart_id": "123",
-        "modified": "20150723191300410",
+        "modified": "20151005183430509",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de la Citadelle de Dèas à Didean",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -6997,12 +7203,13 @@
         "map_id": "1",
         "markerend_id": "47",
         "markerstart_id": "70",
-        "modified": "20150723191744453",
+        "modified": "20151005183430509",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Llewellen à Tulg Naomh",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -7014,12 +7221,13 @@
         "map_id": "1",
         "markerend_id": "70",
         "markerstart_id": "133",
-        "modified": "20150723191902451",
+        "modified": "20151005183430510",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Louarn à Llewellen",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -7031,12 +7239,13 @@
         "map_id": "1",
         "markerend_id": "30",
         "markerstart_id": "121",
-        "modified": "20150723192151050",
+        "modified": "20151005183430510",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Norgord (des carrières de Norgord à l'abbaye de Corvus)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -7048,12 +7257,13 @@
         "map_id": "1",
         "markerend_id": "37",
         "markerstart_id": "118",
-        "modified": "20150723192238120",
+        "modified": "20151005183430510",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Promesse",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -7065,12 +7275,13 @@
         "map_id": "1",
         "markerend_id": "62",
         "markerstart_id": "59",
-        "modified": "20150723192909987",
+        "modified": "20151005183430511",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Ruel (d'Ard-Monach au carrefour de Ruel)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -7082,12 +7293,13 @@
         "map_id": "1",
         "markerend_id": "132",
         "markerstart_id": "117",
-        "modified": "20150723192942481",
+        "modified": "20151005183430511",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Ruel (du carrefour de Jarnel à Kaer Daegis)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -7099,12 +7311,13 @@
         "map_id": "1",
         "markerend_id": "117",
         "markerstart_id": "62",
-        "modified": "20150723193604796",
+        "modified": "20151005183430511",
         "routetype_id": "1",
         "status": "à revoir",
         "tags": "routes",
         "title": "Chemin de Ruel (du carrefour de Ruel au carrefour de Jarnel)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -7116,12 +7329,13 @@
         "map_id": "1",
         "markerend_id": "129",
         "markerstart_id": "10",
-        "modified": "20150723194728095",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Océan (d'Aimliù à Diinthër)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     },
     {
         "text": "",
@@ -7133,12 +7347,12 @@
         "map_id": "1",
         "markerend_id": "9",
         "markerstart_id": "129",
-        "modified": "20150723194737843",
+        "modified": "20151005183430521",
         "routetype_id": "2",
         "status": "à revoir",
         "tags": "routes",
         "title": "Route de l'Océan (de Diinthër à Ard-Amrach)",
-        "zoneparent_id": ""
+        "zoneparent_id": "",
+        "guarded": "false"
     }
 ]
-


### PR DESCRIPTION
The field is set to the string "false" by default.

Other modifications are the cascading of the Royaume de Gwidre and Royaume de Reizh IDs to the zoneparent_id field of their children, and the status of the placed zones.

As mentionned in #27, some IDs don't match with the DB.
